### PR TITLE
feat: D-HF curve-aware directed Hausdorff (arc-length densify, in-library)

### DIFF
--- a/src/NetTopologySuite/Algorithm/Distance/CurveDiscreteHausdorffDistance.cs
+++ b/src/NetTopologySuite/Algorithm/Distance/CurveDiscreteHausdorffDistance.cs
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: BSD-3-Clause AND CC0-1.0
+//
+// AI assistance disclosure:
+//   AI-drafted, human-reviewed and curated. AI-generated portions are dedicated
+//   to CC0-1.0; human curation falls under the NTS BSD-3-Clause grant.
+//
+//   Assisted-by: Claude / Grok (xAI)
+//
+// TAG D-HF (JTS epic #1195 Phase 3; proofs #423): curve-aware discrete /
+// directed Hausdorff densified by arc length, not control chords.
+// In-library (Geometries.Curves.*) — not the out-of-tree NetTopologySuite.Curve package.
+
+using System;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.Geometries.Curves;
+
+namespace NetTopologySuite.Algorithm.Distance
+{
+    /// <summary>
+    /// Curve-aware discrete / directed Hausdorff distance (TAG D-HF).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Core <see cref="DiscreteHausdorffDistance"/> densifies straight control
+    /// chords (or vertices only). This class densifies
+    /// <see cref="CircularString"/> / <see cref="CompoundCurve"/> by
+    /// <em>arc length</em>: each arc is sampled at equal arc-length steps
+    /// controlled by a densify fraction (JTS #1195 Phase 3; proofs #423).
+    /// </para>
+    /// <para>
+    /// Directed form: <c>h(A,B) = max<sub>a∈A</sub> min<sub>b∈B</sub> d(a,b)</c>
+    /// (Huttenlocher–Klanderman–Rucklidge). Non-curve query geometries fall
+    /// through to <see cref="DiscreteHausdorffDistance"/>.
+    /// </para>
+    /// </remarks>
+    public static class CurveDiscreteHausdorffDistance
+    {
+        /// <summary>
+        /// Default densify fraction (equal-arc-length steps ≈ 1/20 of each arc).
+        /// </summary>
+        public const double DefaultDensifyFraction = 0.05;
+
+        /// <summary>
+        /// Oriented (directed) discrete Hausdorff from <paramref name="a"/> to
+        /// <paramref name="b"/>, densifying curve components by arc length at
+        /// <see cref="DefaultDensifyFraction"/>.
+        /// </summary>
+        public static double OrientedDistance(Geometry a, Geometry b)
+        {
+            return OrientedDistance(a, b, DefaultDensifyFraction);
+        }
+
+        /// <summary>
+        /// Oriented (directed) discrete Hausdorff from <paramref name="a"/> to
+        /// <paramref name="b"/> with arc-length densify fraction.
+        /// </summary>
+        /// <param name="a">Query geometry (samples taken on this side).</param>
+        /// <param name="b">Target geometry (nearest-point distance).</param>
+        /// <param name="densifyFraction">
+        /// Fraction of each arc's length between sample points, in (0, 1].
+        /// <c>0.05</c> ≈ 20 equal-arc-length steps per arc (plus endpoints).
+        /// </param>
+        /// <returns>The oriented discrete Hausdorff distance h(a,b).</returns>
+        public static double OrientedDistance(Geometry a, Geometry b, double densifyFraction)
+        {
+            if (a == null) throw new ArgumentNullException(nameof(a));
+            if (b == null) throw new ArgumentNullException(nameof(b));
+            if (a.IsEmpty || b.IsEmpty)
+                return 0d;
+            if (densifyFraction <= 0d || densifyFraction > 1d)
+                throw new ArgumentOutOfRangeException(nameof(densifyFraction),
+                    "Fraction is not in range (0.0 - 1.0]");
+
+            if (a is CircularString cs)
+                return OrientedFromCircularString(cs, b, densifyFraction);
+            if (a is CompoundCurve cc)
+                return OrientedFromCompoundCurve(cc, b, densifyFraction);
+
+            var dist = new DiscreteHausdorffDistance(a, b)
+            {
+                DensifyFraction = densifyFraction
+            };
+            return dist.OrientedDistance();
+        }
+
+        /// <summary>
+        /// Symmetric discrete Hausdorff <c>max(h(a,b), h(b,a))</c> with
+        /// arc-length densify on whichever operand is a curve.
+        /// </summary>
+        public static double Distance(Geometry a, Geometry b,
+            double densifyFraction = DefaultDensifyFraction)
+        {
+            return Math.Max(
+                OrientedDistance(a, b, densifyFraction),
+                OrientedDistance(b, a, densifyFraction));
+        }
+
+        private static double OrientedFromCompoundCurve(CompoundCurve cc, Geometry target,
+            double densifyFraction)
+        {
+            double max = 0d;
+            foreach (var member in cc.Curves)
+            {
+                double h = member is CircularString cs
+                    ? OrientedFromCircularString(cs, target, densifyFraction)
+                    : OrientedDistance(member, target, densifyFraction);
+                if (h > max) max = h;
+            }
+            return max;
+        }
+
+        private static double OrientedFromCircularString(CircularString cs, Geometry target,
+            double densifyFraction)
+        {
+            int numArcs = cs.NumArcs;
+            if (numArcs == 0)
+                return OrientedFromCoordinates(cs.CoordinateSequence, target);
+
+            var maxPtDist = new PointPairDistance();
+            int numSubSegs = Math.Max(1,
+                (int)Math.Round(1.0 / densifyFraction, MidpointRounding.ToEven));
+            var seq = cs.CoordinateSequence;
+
+            for (int i = 0; i < numArcs; i++)
+            {
+                int o = i * 2;
+                var p0 = seq.GetCoordinate(o);
+                var p1 = seq.GetCoordinate(o + 1);
+                var p2 = seq.GetCoordinate(o + 2);
+                SampleArcByArcLength(p0, p1, p2, numSubSegs, target, maxPtDist);
+            }
+
+            return maxPtDist.Distance;
+        }
+
+        private static double OrientedFromCoordinates(CoordinateSequence seq, Geometry target)
+        {
+            var maxPtDist = new PointPairDistance();
+            for (int i = 0; i < seq.Count; i++)
+            {
+                var minPtDist = new PointPairDistance();
+                DistanceToPoint.ComputeDistance(target, seq.GetCoordinate(i), minPtDist);
+                maxPtDist.SetMaximum(minPtDist);
+            }
+            return maxPtDist.Distance;
+        }
+
+        /// <summary>
+        /// Sample one circular arc (p0, on-arc p1, p2) at equal arc-length steps
+        /// and accumulate max nearest-distance to <paramref name="target"/>.
+        /// </summary>
+        private static void SampleArcByArcLength(Coordinate p0, Coordinate p1, Coordinate p2,
+            int numSubSegs, Geometry target, PointPairDistance maxPtDist)
+        {
+            UpdateMax(target, p0, maxPtDist);
+            UpdateMax(target, p2, maxPtDist);
+
+            // Collinear control triple → straight segment (mid + chord densify).
+            if (Orientation.Index(p0, p1, p2) == OrientationIndex.Collinear
+                || p0.Equals2D(p2))
+            {
+                UpdateMax(target, p1, maxPtDist);
+                if (!p0.Equals2D(p2))
+                    ChordSample(p0, p2, numSubSegs, target, maxPtDist);
+                return;
+            }
+
+            // Geometries.Triangle (coordinate utility), not Curves.Triangle (OGC type).
+            var center = Geometries.Triangle.Circumcentre(p0, p1, p2);
+            double r = center.Distance(p0);
+            if (double.IsNaN(r) || r == 0d || double.IsInfinity(r))
+            {
+                UpdateMax(target, p1, maxPtDist);
+                ChordSample(p0, p2, numSubSegs, target, maxPtDist);
+                return;
+            }
+
+            // Oriented sweep P0 → P1 → P2 (same construction as arc angle sum).
+            double a0 = AngleUtility.Angle(center, p0);
+            double sweep01 = AngleUtility.AngleBetweenOriented(p0, center, p1);
+            double sweep12 = AngleUtility.AngleBetweenOriented(p1, center, p2);
+            if (Math.Sign(sweep12) != Math.Sign(sweep01) && sweep01 != 0d)
+                sweep12 += -Math.Sign(sweep12) * AngleUtility.PiTimes2;
+            double totalSweep = sweep01 + sweep12;
+            if (Math.Abs(totalSweep) < 1e-15)
+            {
+                UpdateMax(target, p1, maxPtDist);
+                return;
+            }
+
+            // Equal arc-length steps ≡ equal angle steps on a circle.
+            for (int i = 1; i < numSubSegs; i++)
+            {
+                double t = (double)i / numSubSegs;
+                double angle = a0 + t * totalSweep;
+                var pt = new Coordinate(
+                    center.X + r * Math.Cos(angle),
+                    center.Y + r * Math.Sin(angle));
+                UpdateMax(target, pt, maxPtDist);
+            }
+
+            // On-arc mid control: never drop a known sample (vertex coverage).
+            UpdateMax(target, p1, maxPtDist);
+        }
+
+        private static void ChordSample(Coordinate p0, Coordinate p1, int numSubSegs,
+            Geometry target, PointPairDistance maxPtDist)
+        {
+            double delx = (p1.X - p0.X) / numSubSegs;
+            double dely = (p1.Y - p0.Y) / numSubSegs;
+            for (int i = 1; i < numSubSegs; i++)
+            {
+                UpdateMax(target, new Coordinate(p0.X + i * delx, p0.Y + i * dely), maxPtDist);
+            }
+        }
+
+        private static void UpdateMax(Geometry target, Coordinate pt, PointPairDistance maxPtDist)
+        {
+            var minPtDist = new PointPairDistance();
+            DistanceToPoint.ComputeDistance(target, pt, minPtDist);
+            maxPtDist.SetMaximum(minPtDist);
+        }
+    }
+}

--- a/test/NetTopologySuite.Tests.NUnit/Algorithm/Distance/CurveDiscreteHausdorffDistanceTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Algorithm/Distance/CurveDiscreteHausdorffDistanceTest.cs
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: BSD-3-Clause AND CC0-1.0
+// AI-drafted, human-reviewed. Assisted-by: Claude / Grok (xAI)
+//
+// TAG D-HF green pin — arc-length densify for curve directed Hausdorff.
+// In-library Geometries.Curves (NTS #854), not NetTopologySuite.Curve package.
+
+using NetTopologySuite.Algorithm.Distance;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.Geometries.Curves;
+using NetTopologySuite.IO;
+using NUnit.Framework;
+
+namespace NetTopologySuite.Tests.NUnit.Algorithm.Distance
+{
+    /// <summary>
+    /// Green pin for TAG D-HF (curve-aware discrete / directed Hausdorff).
+    /// </summary>
+    /// <remarks>
+    /// Witness: asymmetric <c>CIRCULARSTRING (0 0, 2 3, 10 0)</c> vs baseline
+    /// <c>LINESTRING (0 0, 10 0)</c>. Continuous directed Hausdorff (apex of the
+    /// circle above the x-axis) is ≈ 3.96764. Control-point discrete densify
+    /// under-estimates at mid-control height 3; arc-length densify via
+    /// <see cref="CurveDiscreteHausdorffDistance"/> approaches continuous.
+    /// </remarks>
+    public class CurveDiscreteHausdorffDistanceTest
+    {
+        /// <summary>
+        /// Continuous directed Hausdorff h(arc, baseline) for the witness arc
+        /// (analytic max height of the circle through (0,0),(2,3),(10,0)
+        /// above the x-axis; centre (5, −7/6), r ≈ 5.134).
+        /// </summary>
+        private const double ExpectedContinuous = 3.96764;
+
+        private const double Tol = 1e-3;
+
+        private readonly WKTReader _reader = new WKTReader();
+
+        [Test]
+        public void OrientedHausdorff_samplesArcNotControlChords()
+        {
+            var arc = _reader.Read("CIRCULARSTRING (0 0, 2 3, 10 0)");
+            var baseline = _reader.Read("LINESTRING (0 0, 10 0)");
+
+            Assert.That(arc, Is.InstanceOf<CircularString>());
+
+            var cs = (CircularString)arc;
+            var controlCoords = cs.CoordinateSequence.ToCoordinateArray();
+            var controlPolyline = arc.Factory.CreateLineString(controlCoords);
+
+            double controlOnly = new DiscreteHausdorffDistance(controlPolyline, baseline)
+                .OrientedDistance();
+            double controlChordDensify = new DiscreteHausdorffDistance(controlPolyline, baseline)
+            {
+                DensifyFraction = 0.05
+            }.OrientedDistance();
+
+            double curveAware = CurveDiscreteHausdorffDistance.OrientedDistance(
+                cs, baseline, densifyFraction: 0.05);
+
+            Assert.That(controlOnly, Is.EqualTo(3.0).Within(1e-9),
+                "control-only discrete stays at mid-control height 3");
+            Assert.That(controlChordDensify, Is.EqualTo(3.0).Within(1e-9),
+                "control-chord densify cannot exceed mid-control height");
+
+            Assert.That(curveAware, Is.EqualTo(ExpectedContinuous).Within(Tol),
+                "D-HF: arc-length densify should approach continuous h≈"
+                + ExpectedContinuous + "; got " + curveAware);
+        }
+
+        [Test]
+        public void DefaultDensifyFraction_matchesExplicit()
+        {
+            var cs = (CircularString)_reader.Read("CIRCULARSTRING (0 0, 2 3, 10 0)");
+            var baseline = _reader.Read("LINESTRING (0 0, 10 0)");
+
+            double withDefault = CurveDiscreteHausdorffDistance.OrientedDistance(cs, baseline);
+            double withExplicit = CurveDiscreteHausdorffDistance.OrientedDistance(cs, baseline, 0.05);
+
+            Assert.That(withDefault, Is.EqualTo(withExplicit).Within(1e-12));
+            Assert.That(withDefault, Is.EqualTo(ExpectedContinuous).Within(Tol));
+        }
+
+        [Test]
+        public void SymmetricDistance_isMaxOfBothDirections()
+        {
+            var cs = (CircularString)_reader.Read("CIRCULARSTRING (0 0, 2 3, 10 0)");
+            var baseline = _reader.Read("LINESTRING (0 0, 10 0)");
+
+            double hAb = CurveDiscreteHausdorffDistance.OrientedDistance(cs, baseline, 0.05);
+            double hBa = CurveDiscreteHausdorffDistance.OrientedDistance(baseline, cs, 0.05);
+            double h = CurveDiscreteHausdorffDistance.Distance(cs, baseline, 0.05);
+
+            Assert.That(h, Is.EqualTo(System.Math.Max(hAb, hBa)).Within(1e-12));
+            Assert.That(hAb, Is.EqualTo(ExpectedContinuous).Within(Tol));
+            // Reverse direction densifies the chord query; nearest-on-arc for a
+            // CircularString target still uses the control graph today, so hBa is
+            // not yet pinned to continuous. Only the max-of-both definition is.
+            Assert.That(hBa, Is.GreaterThanOrEqualTo(0.0));
+        }
+
+        [Test]
+        public void CompoundCurve_delegatesCircularMembers()
+        {
+            // Line segment + the asymmetric arc, continuous.
+            var cc = (CompoundCurve)_reader.Read(
+                "COMPOUNDCURVE ((-1 0, 0 0), CIRCULARSTRING (0 0, 2 3, 10 0))");
+            var baseline = _reader.Read("LINESTRING (-1 0, 10 0)");
+
+            double h = CurveDiscreteHausdorffDistance.OrientedDistance(cc, baseline, 0.05);
+            Assert.That(h, Is.EqualTo(ExpectedContinuous).Within(Tol),
+                "CompoundCurve should densify CircularString members by arc length");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **In-library D-HF** for the curve MVP ([upstream #854](https://github.com/NetTopologySuite/NetTopologySuite/pull/854)), not the out-of-tree `NetTopologySuite.Curve` package.
- New `CurveDiscreteHausdorffDistance`: densifies `CircularString` / `CompoundCurve` by **equal arc-length** steps (`densifyFraction`, default `0.05`). Non-curve queries fall through to core `DiscreteHausdorffDistance`.
- Green pin suite on the asymmetric arc witness (continuous apex ≈ **3.96764**; control-only discrete stays **3**).

## Stacking

Base: `mvp/curves-on-develop` (same head as upstream PR #854). Merge after / with that MVP.

## Witness

| Reading | `h(A,B)` |
|---|---|
| Continuous apex | ≈ 3.96764 |
| Control-only discrete | 3.0 |
| Arc-length densify `0.05` | ≈ 3.96764 |

`A = CIRCULARSTRING (0 0, 2 3, 10 0)`, `B = LINESTRING (0 0, 10 0)`.

## Test plan

- [x] `dotnet test --filter FullyQualifiedName~CurveDiscreteHausdorffDistanceTest -p:EnableApiCompat=false` → **4 passed**

Refs: NetTopologySuite/NetTopologySuite#854, proofs #423, JTS D-HF / #1195.