### PR TITLE
S4: closed-form circular ring length and area

### DIFF
--- a/src/NetTopologySuite/Algorithm/ExactCurve/ExactCircularArc.cs
+++ b/src/NetTopologySuite/Algorithm/ExactCurve/ExactCircularArc.cs
@@ -214,6 +214,29 @@ namespace NetTopologySuite.Algorithm.ExactCurve
             return OnSweep(p);
         }
 
+        /// <summary>
+        /// Contour-integral contribution <c>½ ∫(x dy − y dx)</c> of this window.
+        /// </summary>
+        public static double SignedAreaContribution(Coordinate start, Coordinate mid, Coordinate end)
+        {
+            return new ExactCircularArc(start, mid, end).SignedAreaContribution();
+        }
+
+        /// <summary>
+        /// Contour-integral contribution <c>½ ∫(x dy − y dx)</c> of this window.
+        /// </summary>
+        public double SignedAreaContribution()
+        {
+            if (!_arc)
+            {
+                return 0.5 * (_start.X * _end.Y - _end.X * _start.Y);
+            }
+            double signed = _ccw ? _sweep : -_sweep;
+            return 0.5 * (_r * _r * signed
+                + _cx * _r * (Math.Sin(_a0 + signed) - Math.Sin(_a0))
+                - _cy * _r * (Math.Cos(_a0 + signed) - Math.Cos(_a0)));
+        }
+
         /// <summary>Circular-segment area <c>r²/2 · (θ − sin θ)</c>. Zero on a chord.</summary>
         public double CircularSegmentArea()
         {

--- a/src/NetTopologySuite/Algorithm/ExactCurve/ExactCircularArc.cs
+++ b/src/NetTopologySuite/Algorithm/ExactCurve/ExactCircularArc.cs
@@ -217,6 +217,12 @@ namespace NetTopologySuite.Algorithm.ExactCurve
         /// <summary>
         /// Contour-integral contribution <c>½ ∫(x dy − y dx)</c> of this window.
         /// </summary>
+        /// <remarks>
+        /// Maintainability: CurvePolygon.Area sums one term per 3-control window.
+        /// Soundness: shoelace on r=3 control points is 18, not <c>9π</c>.
+        /// Performance: one closed-form term; the static overload allocates one window.
+        /// Port of JTS <c>9808dfa1</c>.
+        /// </remarks>
         public static double SignedAreaContribution(Coordinate start, Coordinate mid, Coordinate end)
         {
             return new ExactCircularArc(start, mid, end).SignedAreaContribution();

--- a/src/NetTopologySuite/Geometries/Curves/CircularString.cs
+++ b/src/NetTopologySuite/Geometries/Curves/CircularString.cs
@@ -27,10 +27,9 @@ namespace NetTopologySuite.Geometries.Curves
     /// with adjacent arcs sharing endpoints.  An empty <c>CircularString</c> has zero
     /// coordinates.
     /// <para/>
-    /// This is a prototype.  In particular, <c>Length</c> and <c>Boundary</c> currently
-    /// fall back to chord-based computations (treating the control points as a polyline)
-    /// rather than analytical arc geometry; the inherited <see cref="Curve.IsClosed"/>
-    /// semantics still apply (start equals end).
+    /// This is a prototype. <c>Length</c> is the closed-form arc sum;
+    /// <c>Boundary</c> still uses the Mod-2 endpoints. The inherited
+    /// <see cref="Curve.IsClosed"/> semantics still apply (start equals end).
     /// </remarks>
     [Serializable]
     public class CircularString : Curve, ILinearizable<LineString>

--- a/src/NetTopologySuite/Geometries/Curves/CircularString.cs
+++ b/src/NetTopologySuite/Geometries/Curves/CircularString.cs
@@ -130,10 +130,33 @@ namespace NetTopologySuite.Geometries.Curves
         public override OgcGeometryType OgcGeometryType => OgcGeometryType.CircularString;
 
         /// <summary>
-        /// Length approximated by summing arc-chord lengths.  Analytical arc-length
-        /// computation is tracked in the prototype roadmap.
+        /// True arc length, summed over each 3-control window.
         /// </summary>
-        public override double Length => Algorithm.Length.OfLine(_points);
+        /// <remarks>
+        /// Maintainability: each window is <see cref="ExactCircularArc.LengthOf"/>.
+        /// Soundness: chord walk on r=2 is <c>8√2</c>, not <c>4π</c>.
+        /// Performance: one hypot plus one multiply per window.
+        /// Port of JTS <c>9808dfa1</c>.
+        /// </remarks>
+        public override double Length
+        {
+            get
+            {
+                if (_points.Count < 3)
+                {
+                    return 0d;
+                }
+                double total = 0d;
+                for (int i = 0; i + 2 < _points.Count; i += 2)
+                {
+                    total += Algorithm.ExactCurve.ExactCircularArc.LengthOf(
+                        _points.GetCoordinate(i),
+                        _points.GetCoordinate(i + 1),
+                        _points.GetCoordinate(i + 2));
+                }
+                return total;
+            }
+        }
 
         /// <summary>
         /// The boundary of a curve per the Mod-2 rule: empty when the curve is empty

--- a/src/NetTopologySuite/Geometries/Curves/CurvePolygon.cs
+++ b/src/NetTopologySuite/Geometries/Curves/CurvePolygon.cs
@@ -242,8 +242,8 @@ namespace NetTopologySuite.Geometries.Curves
         }
 
         /// <summary>
-        /// Perimeter approximated by summing ring lengths (chord-based for curved
-        /// rings).
+        /// Perimeter: sum of structural ring lengths. Circular rings use the
+        /// closed-form <see cref="CircularString.Length"/>.
         /// </summary>
         public override double Length
         {

--- a/src/NetTopologySuite/Geometries/Curves/CurvePolygon.cs
+++ b/src/NetTopologySuite/Geometries/Curves/CurvePolygon.cs
@@ -17,6 +17,7 @@
 
 using System;
 using System.Collections.Generic;
+using NetTopologySuite.Algorithm.ExactCurve;
 
 namespace NetTopologySuite.Geometries.Curves
 {
@@ -185,23 +186,59 @@ namespace NetTopologySuite.Geometries.Curves
         }
 
         /// <summary>
-        /// Area approximated by treating the control points of the rings as polyline
-        /// rings (chord-based, consistent with <see cref="CircularString"/>'s
-        /// chord-based <c>Length</c>).  For curved rings the true area differs by the
-        /// circular segments; analytical arc area is tracked in the prototype roadmap.
+        /// Area enclosed by the structural rings, so arc rings contribute the
+        /// area they actually sweep rather than the polygon through their control
+        /// points.
         /// </summary>
+        /// <remarks>
+        /// Maintainability: each window uses <see cref="ExactCircularArc.SignedAreaContribution"/>.
+        /// Soundness: control-point shoelace on r=3 is 18, not <c>9π</c>.
+        /// Performance: one closed-form term per window.
+        /// Port of JTS <c>9808dfa1</c>.
+        /// </remarks>
         public override double Area
         {
             get
             {
                 if (IsEmpty) return 0d;
-                double area = Algorithm.Area.OfRing(_shell.Coordinates);
+                double area = Math.Abs(SignedRingArea(_shell));
                 foreach (var hole in _holes)
                 {
-                    area -= Algorithm.Area.OfRing(hole.Coordinates);
+                    area -= Math.Abs(SignedRingArea(hole));
                 }
                 return area;
             }
+        }
+
+        private static double SignedRingArea(Curve ring)
+        {
+            if (ring == null || ring.IsEmpty)
+            {
+                return 0d;
+            }
+            if (ring is CompoundCurve cc)
+            {
+                double area = 0d;
+                foreach (var member in cc.Curves)
+                {
+                    area += SignedRingArea(member);
+                }
+                return area;
+            }
+            if (ring is CircularString cs && cs.NumPoints >= 3)
+            {
+                var seq = cs.CoordinateSequence;
+                double area = 0d;
+                for (int i = 0; i + 2 < seq.Count; i += 2)
+                {
+                    area += ExactCircularArc.SignedAreaContribution(
+                        seq.GetCoordinate(i),
+                        seq.GetCoordinate(i + 1),
+                        seq.GetCoordinate(i + 2));
+                }
+                return area;
+            }
+            return Algorithm.Area.OfRing(ring.Coordinates);
         }
 
         /// <summary>

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/CircularRingMetricsTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/CircularRingMetricsTest.cs
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// AI assistance disclosure:
+//   AI-drafted, human-reviewed. Assisted-by: Cursor Grok 4.6
+//   AI-generated portions dedicated to CC0-1.0; human curation BSD-3-Clause.
+
+using System;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
+using NUnit.Framework;
+
+namespace NetTopologySuite.Tests.NUnit.Geometries.Curves
+{
+    /// <summary>
+    /// Closed-form circular ring length and area.
+    /// Witness: r=2 circle length is 4π (was 8√2); r=3 disc area is 9π (was 18).
+    /// Port of JTS <c>9808dfa1</c>.
+    /// </summary>
+    public class CircularRingMetricsTest
+    {
+        private readonly WKTReader _reader = new WKTReader();
+
+        [Test]
+        public void Radius2CircleLengthIsFourPi()
+        {
+            var g = _reader.Read("CURVEPOLYGON (CIRCULARSTRING (-2 0, 0 2, 2 0, 0 -2, -2 0))");
+            Assert.That(g.Length, Is.EqualTo(4.0 * Math.PI).Within(1.0e-9));
+            Assert.That(g.Length, Is.Not.EqualTo(8.0 * Math.Sqrt(2)).Within(1.0e-6));
+        }
+
+        [Test]
+        public void Radius3DiscAreaIsNinePi()
+        {
+            var g = _reader.Read("CURVEPOLYGON (CIRCULARSTRING (-3 0, 0 3, 3 0, 0 -3, -3 0))");
+            Assert.That(g.Area, Is.EqualTo(9.0 * Math.PI).Within(1.0e-9));
+            Assert.That(g.Area, Is.Not.EqualTo(18.0).Within(1.0e-6));
+        }
+
+        [Test]
+        public void CircularStringLengthMatchesArc()
+        {
+            var g = _reader.Read("CIRCULARSTRING (-2 0, 0 2, 2 0, 0 -2, -2 0)");
+            Assert.That(g.Length, Is.EqualTo(4.0 * Math.PI).Within(1.0e-9));
+        }
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository.
- [x] I have provided test coverage for my change (where applicable)

### Description

One behaviour: circular ring `Length` / `Area` use closed-form windows, not control-point chords.

Port of JTS [`9808dfa1`](https://github.com/grootstebozewolf/jts/commit/9808dfa1). **Unstacked** on fork `develop` after S3 [#10](https://github.com/grootstebozewolf/NetTopologySuite/pull/10) merged. Tip context: JTS #7 `a10708ed`.

**Witness:** r=2 circle length is **4π** (was 8√2). r=3 disc area is **9π** (was 18). Tests 18/18 (15 S3 + 3 S4).

Maintainability: each window is `ExactCircularArc.LengthOf` / `SignedAreaContribution`.
Soundness: chord walk on r=2 is 8√2, not 4π; shoelace on r=3 is 18, not 9π.
Performance: one closed-form term per window.

GEOS already has this (skip). OverlayNGCurve kits stay later (S8).

AI-drafted, human-reviewed. Assisted-by: Cursor Grok 4.6. AI-generated portions dedicated to CC0-1.0; human curation BSD-3-Clause.

I have read and agree to the [NTS contributor license agreement](https://gist.github.com/FObermaier/2db0402438d23227ed66de0d2d4fbe78).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc93a9b6-cabf-416a-943d-5dcc8901ccfa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc93a9b6-cabf-416a-943d-5dcc8901ccfa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

