### PR TITLE
S2: pin mid-control vertices through Linearize(tolerance)

### DIFF
--- a/src/NetTopologySuite/Algorithm/ExactCurve/ExactCircularArc.cs
+++ b/src/NetTopologySuite/Algorithm/ExactCurve/ExactCircularArc.cs
@@ -5,6 +5,7 @@
 //   AI-generated portions dedicated to CC0-1.0; human curation BSD-3-Clause.
 
 using System;
+using System.Collections.Generic;
 using NetTopologySuite.Geometries;
 
 namespace NetTopologySuite.Algorithm.ExactCurve
@@ -131,15 +132,40 @@ namespace NetTopologySuite.Algorithm.ExactCurve
             {
                 delta = -delta;
             }
-            var pts = new Coordinate[segments + 1];
-            pts[0] = _start.Copy();
+            var pts = new List<Coordinate>(segments + 2) { _start.Copy() };
+            double midEps = Math.Max(1.0e-12, _r * 1.0e-9);
+            bool midEmitted = _mid.Equals2D(_start) || _mid.Equals2D(_end);
             for (int i = 1; i < segments; i++)
             {
                 double ang = _a0 + i * delta;
-                pts[i] = new Coordinate(_cx + _r * Math.Cos(ang), _cy + _r * Math.Sin(ang));
+                var pt = new Coordinate(_cx + _r * Math.Cos(ang), _cy + _r * Math.Sin(ang));
+                if (!midEmitted && pt.Distance(_mid) <= midEps)
+                {
+                    pts.Add(_mid.Copy());
+                    midEmitted = true;
+                    continue;
+                }
+                pts.Add(pt);
             }
-            pts[segments] = _end.Copy();
-            return GeometryFactory.Default.CreateLineString(pts);
+            if (!midEmitted)
+            {
+                double midSweep = AngleBetween.Travelled(_ccw,
+                    _start.X - _cx, _start.Y - _cy, _mid.X - _cx, _mid.Y - _cy);
+                int insertAt = pts.Count;
+                for (int i = 1; i < pts.Count; i++)
+                {
+                    double s = AngleBetween.Travelled(_ccw,
+                        _start.X - _cx, _start.Y - _cy, pts[i].X - _cx, pts[i].Y - _cy);
+                    if (s >= midSweep)
+                    {
+                        insertAt = i;
+                        break;
+                    }
+                }
+                pts.Insert(insertAt, _mid.Copy());
+            }
+            pts.Add(_end.Copy());
+            return GeometryFactory.Default.CreateLineString(pts.ToArray());
         }
 
         public bool ChordLeArc()

--- a/src/NetTopologySuite/Algorithm/ExactCurve/ExactCircularArc.cs
+++ b/src/NetTopologySuite/Algorithm/ExactCurve/ExactCircularArc.cs
@@ -115,6 +115,13 @@ namespace NetTopologySuite.Algorithm.ExactCurve
         }
 
         /// <summary>Documented densify shim. Not used by <see cref="Length"/> or <see cref="PointAt"/>.</summary>
+        /// <remarks>
+        /// Maintainability: emit the supplied mid-control on a sweep-angle tie
+        /// so callers can match the input vertex after Linearize.
+        /// Soundness: <c>cos(π/2)</c> is not <c>(0, 1)</c>.
+        /// Performance: one extra distance test per interpolated vertex.
+        /// Port of JTS <c>f6347444</c>.
+        /// </remarks>
         public Geometry ToLinear(double tolerance)
         {
             if (tolerance < 0.0)

--- a/src/NetTopologySuite/Geometries/Curves/CircularString.cs
+++ b/src/NetTopologySuite/Geometries/Curves/CircularString.cs
@@ -276,20 +276,48 @@ namespace NetTopologySuite.Geometries.Curves
         public LineString Linearize() => Linearize(double.NaN);
 
         /// <summary>
-        /// Returns a chord approximation of this circular string as a
-        /// <see cref="LineString"/>.
+        /// Densifies this circular string. A non-finite tolerance still returns
+        /// the control polyline. A finite tolerance uses sagitta densify and
+        /// keeps every supplied control as an exact vertex.
         /// </summary>
-        /// <param name="arcSegmentLength">
-        /// Reserved for maximum chord length along each arc. Currently unused;
-        /// control-point chords are always returned.
-        /// </param>
+        /// <remarks>
+        /// Maintainability: keep the supplied mid-control as a vertex so
+        /// callers can match on the input coordinates after Linearize.
+        /// Soundness: cos/sin at π/2 is not (0,1); the control is the sample
+        /// that was supplied. On a sweep-angle tie the control wins.
+        /// Performance: one extra distance test per interpolated vertex.
+        /// Port of JTS <c>f6347444</c>.
+        /// </remarks>
         public LineString Linearize(double arcSegmentLength)
         {
             if (IsEmpty)
             {
                 return Factory.CreateLineString();
             }
-            return Factory.CreateLineString(_points.Copy());
+            if (double.IsNaN(arcSegmentLength) || double.IsInfinity(arcSegmentLength))
+            {
+                return Factory.CreateLineString(_points.Copy());
+            }
+            if (arcSegmentLength < 0.0)
+            {
+                throw new ArgumentException("tolerance must be non-negative: " + arcSegmentLength,
+                    nameof(arcSegmentLength));
+            }
+            var pts = new List<Coordinate>();
+            for (int i = 0; i + 2 < _points.Count; i += 2)
+            {
+                var arc = new Algorithm.ExactCurve.ExactCircularArc(
+                    _points.GetCoordinate(i),
+                    _points.GetCoordinate(i + 1),
+                    _points.GetCoordinate(i + 2));
+                var lin = (LineString)arc.ToLinear(arcSegmentLength);
+                int start = pts.Count == 0 ? 0 : 1;
+                for (int k = start; k < lin.NumPoints; k++)
+                {
+                    pts.Add(lin.GetCoordinateN(k));
+                }
+            }
+            return Factory.CreateLineString(pts.ToArray());
         }
     }
 }

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/LinearizeAnchorPinningTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/LinearizeAnchorPinningTest.cs
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// AI assistance disclosure:
+//   AI-drafted, human-reviewed. Assisted-by: Cursor Grok 4.6
+//   AI-generated portions dedicated to CC0-1.0; human curation BSD-3-Clause.
+
+using NetTopologySuite.Geometries;
+using NetTopologySuite.Geometries.Curves;
+using NUnit.Framework;
+
+namespace NetTopologySuite.Tests.NUnit.Geometries.Curves
+{
+    /// <summary>
+    /// Control points survive Linearize(tolerance) exactly.
+    /// Witness: CIRCULARSTRING (1 0, 0 1, -1 0) keeps exact (0, 1).
+    /// Port of JTS <c>f6347444</c>.
+    /// </summary>
+    public class LinearizeAnchorPinningTest
+    {
+        private readonly GeometryFactory _factory = new GeometryFactory();
+
+        [Test]
+        public void MidControlExactOnSweepTie()
+        {
+            var cs = Make((1, 0), (0, 1), (-1, 0));
+            var ls = cs.Linearize(0.01);
+            Assert.That(ContainsExactly(ls, new Coordinate(0, 1)), Is.True);
+        }
+
+        [Test]
+        public void AllControlsOfTwoArcStringSurvive()
+        {
+            var cs = Make((1, 0), (0, 1), (-1, 0), (-2, -1), (-3, 0));
+            var ls = cs.Linearize(0.01);
+            Assert.That(ContainsExactly(ls, new Coordinate(1, 0)), Is.True);
+            Assert.That(ContainsExactly(ls, new Coordinate(0, 1)), Is.True);
+            Assert.That(ContainsExactly(ls, new Coordinate(-1, 0)), Is.True);
+            Assert.That(ContainsExactly(ls, new Coordinate(-2, -1)), Is.True);
+            Assert.That(ContainsExactly(ls, new Coordinate(-3, 0)), Is.True);
+        }
+
+        private CircularString Make(params (double x, double y)[] pts)
+        {
+            var coords = new Coordinate[pts.Length];
+            for (int i = 0; i < pts.Length; i++)
+            {
+                coords[i] = new Coordinate(pts[i].x, pts[i].y);
+            }
+            return new CircularString(_factory.CoordinateSequenceFactory.Create(coords), _factory);
+        }
+
+        private static bool ContainsExactly(Geometry g, Coordinate anchor)
+        {
+            foreach (var p in g.Coordinates)
+            {
+                if (p.Equals2D(anchor))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository.
- [x] I have provided test coverage for my change (where applicable)

### Description

One behaviour: `Linearize(tolerance)` keeps the supplied circular-arc control points as exact vertices.

Port of JTS [`f6347444`](https://github.com/grootstebozewolf/jts/commit/f6347444) (DENS-ANCHOR). **Unstacked** on fork `develop` after S3 [#10](https://github.com/grootstebozewolf/NetTopologySuite/pull/10) merged. Tip context: JTS #7 `a10708ed`.

**Witness:** `CIRCULARSTRING (1 0, 0 1, -1 0)` after `Linearize(0.01)` contains exact `(0, 1)`, not `cos(π/2) ≈ 6e-17`. Tests 17/17 (15 S3 + 2 S2).

Maintainability: the mid-control is the sample callers already hold.
Soundness: a sweep-angle tie must not replace the control with a `cos`/`sin` reconstruction.
Performance: one extra distance test per interpolated vertex.

`Linearize()` with a non-finite tolerance still returns the control polyline. No `get_`/`set_` churn.

AI-drafted, human-reviewed. Assisted-by: Cursor Grok 4.6. AI-generated portions dedicated to CC0-1.0; human curation BSD-3-Clause.

I have read and agree to the [NTS contributor license agreement](https://gist.github.com/FObermaier/2db0402438d23227ed66de0d2d4fbe78).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc93a9b6-cabf-416a-943d-5dcc8901ccfa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc93a9b6-cabf-416a-943d-5dcc8901ccfa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

