### PR TITLE
ML.6: port IsRadiusWithin and MIC/LEC auto-tolerance

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
     - name: Get source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v7
 
     - name: Setup .NET 10
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: 10
 
@@ -39,7 +39,7 @@ jobs:
       run: dotnet pack -c Release --no-build -o artifacts -p:NoWarn=NU5105
 
     - name: Upload
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: NuGet Package Files (${{ matrix.os }})
         path: artifacts
@@ -53,12 +53,12 @@ jobs:
 
     steps:
     - name: Setup .NET 10
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: 10
 
     - name: Download Package Files
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@v8
       with:
         name: NuGet Package Files (ubuntu-latest)
         path: artifacts
@@ -78,12 +78,12 @@ jobs:
 
     steps:
     - name: Setup .NET 10
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: 10
 
     - name: Download Package Files
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@v8
       with:
         name: NuGet Package Files (ubuntu-latest)
         path: artifacts

--- a/src/NetTopologySuite.Lab/Algorithm/Rocq/RocqNative.cs
+++ b/src/NetTopologySuite.Lab/Algorithm/Rocq/RocqNative.cs
@@ -2,6 +2,9 @@
 // NetTopologySuite.Lab copy of NetTopologySuite.Proofs oracle/csharp/RocqNative.cs
 // Keep in sync with that file.  Core RobustLineIntersector does not call this.
 // Check RocqNative.IsAvailable before use.
+//
+// ABI ledger: grootstebozewolf/NetTopologySuite.Proofs
+//   docs/phase5-ffi-abi.md  and  oracle/CONSUMERS.md
 // ============================================================================
 // oracle/csharp/RocqNative.cs
 // ----------------------------------------------------------------------------
@@ -167,10 +170,18 @@ namespace NetTopologySuite.Robust.Native
     }
 
     /// <summary>
-    /// Managed façade over the Coq-extracted geometry kernel.  Every method here
-    /// returns exactly what the proofs-repo oracle returns for the same inputs
-    /// (gated by oracle/gen_ffi_parity_tests.py on every build of the proofs).
+    /// Opt-in managed façade over the Coq-extracted geometry kernel
+    /// (<c>libntsrocq</c>). Every method here returns exactly what the
+    /// proofs-repo oracle returns for the same inputs (gated by
+    /// <c>oracle/gen_ffi_parity_tests.py</c> on every build of the proofs).
     /// </summary>
+    /// <remarks>
+    /// This class does not change production noding or orientation defaults.
+    /// Callers must check <see cref="IsAvailable"/> before invoking native
+    /// methods. Source of truth and ABI ledger:
+    /// <c>grootstebozewolf/NetTopologySuite.Proofs</c>
+    /// (<c>docs/phase5-ffi-abi.md</c>, <c>oracle/CONSUMERS.md</c>).
+    /// </remarks>
     public static class RocqNative
     {
         /// <summary>ABI this binding was written against (see nts_ffi.h).</summary>

--- a/src/NetTopologySuite.Lab/Algorithm/Rocq/RocqNative.cs
+++ b/src/NetTopologySuite.Lab/Algorithm/Rocq/RocqNative.cs
@@ -1,0 +1,497 @@
+// ============================================================================
+// NetTopologySuite.Lab copy of NetTopologySuite.Proofs oracle/csharp/RocqNative.cs
+// Keep in sync with that file.  Core RobustLineIntersector does not call this.
+// Check RocqNative.IsAvailable before use.
+// ============================================================================
+// oracle/csharp/RocqNative.cs
+// ----------------------------------------------------------------------------
+// Phase 5 reference binding: the .NET side of `libntsrocq` (oracle/nts_ffi.h).
+//
+// This file is REFERENCE SOURCE, not a compiled artifact of this repository --
+// there is no .NET toolchain in the proofs CI (same status as
+// docs/arc-offset-red-test-example.cs).  It is the copy-in starting point for
+// `NetTopologySuite.Robust.Native` in the NetTopologySuite.Curve consumer,
+// and it is the executable form of the ABI contract: if this file and
+// oracle/nts_ffi.h disagree, one of them is wrong.
+//
+// What it buys over the existing RocqRefRunner: RocqRefRunner shells out to
+// `oracle_bin` and speaks a line protocol -- one process spawn plus two pipe
+// round-trips per predicate call.  That is fine for differential test corpora
+// (which is all it was ever used for) and hopeless inside a noding loop.  These
+// entry points are ordinary p/invoke calls into the same extracted code.
+//
+// Threading: the embedded OCaml 4.14 runtime is not re-entrant, so every call
+// is serialised on `Gate`.  Callers that need parallelism should partition work
+// and batch, not remove the lock.
+//
+// AI disclosure: authored with AI assistance (see CONTRIBUTING.md).
+// ============================================================================
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace NetTopologySuite.Robust.Native
+{
+    /// <summary>5-valued orientation result (Phase 0, b64_orient_sign_filtered).</summary>
+    public enum RocqOrientSign
+    {
+        /// <summary>Clockwise / right turn.</summary>
+        Neg = -1,
+
+        /// <summary>Collinear.</summary>
+        Zero = 0,
+
+        /// <summary>Counter-clockwise / left turn.</summary>
+        Pos = 1,
+
+        /// <summary>A NaN reached the predicate.</summary>
+        Nan = 2,
+
+        /// <summary>The Shewchuk Stage A filter declines to answer. Never a wrong
+        /// sign: escalate to an exact path rather than treating it as Zero.</summary>
+        Uncertain = 3
+    }
+
+    /// <summary>5-valued segment-intersection result (Phase 1).</summary>
+    public enum RocqIntersectSign
+    {
+        None = 0,
+        Point = 1,
+        Collinear = 2,
+        Nan = 3,
+        Uncertain = 4
+    }
+
+    /// <summary>Overlay boolean operation (Phase 3, OverlayGraph.v order).</summary>
+    public enum RocqBooleanOp
+    {
+        Union = 0,
+        Intersection = 1,
+        Difference = 2,
+        SymDiff = 3
+    }
+
+    internal static class RocqNativeMethods
+    {
+        // Resolves to libntsrocq.so / libntsrocq.dylib / ntsrocq.dll.
+        private const string Lib = "ntsrocq";
+
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int nts_rocq_init();
+
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int nts_rocq_abi_version();
+
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int nts_rocq_orient_sign_filtered(
+            double p0x, double p0y, double p1x, double p1y, double qx, double qy);
+
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int nts_rocq_orient_sign_naive(
+            double p0x, double p0y, double p1x, double p1y, double qx, double qy);
+
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern double nts_rocq_orient2d(
+            double p0x, double p0y, double p1x, double p1y, double qx, double qy);
+
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int nts_rocq_orient_sign_exact(
+            double p0x, double p0y, double p1x, double p1y, double qx, double qy);
+
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int nts_rocq_intersect_sign_filtered(
+            double p0x, double p0y, double p1x, double p1y,
+            double q0x, double q0y, double q1x, double q1y);
+
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int nts_rocq_intersect_point(
+            double p0x, double p0y, double p1x, double p1y,
+            double q0x, double q0y, double q1x, double q1y,
+            out double x, out double y);
+
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void nts_rocq_intersect_point_xy(
+            double p0x, double p0y, double p1x, double p1y,
+            double q0x, double q0y, double q1x, double q1y,
+            out double x, out double y);
+
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int nts_rocq_passes_through_hot_pixel(
+            double p0x, double p0y, double p1x, double p1y, double cx, double cy);
+
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int nts_rocq_passes_through_hot_pixel_halfopen(
+            double p0x, double p0y, double p1x, double p1y, double cx, double cy);
+
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern double nts_rocq_snap_coord(double x);
+
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern double nts_rocq_snap_coord_scaled(double x, double scale);
+
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int nts_rocq_edge_in_result(int op, int inLeft, int inRight);
+
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern double nts_rocq_in_circle(
+            double ax, double ay, double bx, double by,
+            double cx, double cy, double px, double py);
+
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int nts_rocq_chord_crosses_arc_circle(
+            double sx, double sy, double mx, double my, double ex, double ey,
+            double px, double py, double qx, double qy);
+
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void nts_rocq_arc_line_intersect_xy(
+            double sx, double sy, double mx, double my, double ex, double ey,
+            double px, double py, double qx, double qy,
+            out double x, out double y);
+
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int nts_rocq_arc_passes_through_hot_pixel(
+            double sx, double sy, double mx, double my, double ex, double ey,
+            double cx, double cy, double scale);
+
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void nts_rocq_two_sum(
+            double x, double y, out double sum, out double err);
+
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int nts_rocq_grow_expansion(
+            double q, double[] xs, int n, double[] outH, int outCap, out double qFinal);
+
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int nts_rocq_simplify_perp(
+            double eps, double[] xy, int nPts, double[] outXy, int outCap);
+    }
+
+    /// <summary>
+    /// Managed façade over the Coq-extracted geometry kernel.  Every method here
+    /// returns exactly what the proofs-repo oracle returns for the same inputs
+    /// (gated by oracle/gen_ffi_parity_tests.py on every build of the proofs).
+    /// </summary>
+    public static class RocqNative
+    {
+        /// <summary>ABI this binding was written against (see nts_ffi.h).</summary>
+        public const int ExpectedAbiVersion = 1;
+
+        private static readonly object Gate = new object();
+
+        private static readonly bool Available;
+
+        static RocqNative()
+        {
+            try
+            {
+                if (RocqNativeMethods.nts_rocq_init() != 0)
+                {
+                    Available = false;
+                    return;
+                }
+
+                int abi = RocqNativeMethods.nts_rocq_abi_version();
+                if (abi != ExpectedAbiVersion)
+                {
+                    Available = false;
+                    return;
+                }
+
+                Available = true;
+            }
+            catch (DllNotFoundException)
+            {
+                Available = false;
+            }
+            catch (BadImageFormatException)
+            {
+                Available = false;
+            }
+        }
+
+        /// <summary>True when <c>libntsrocq</c> loaded and the ABI matched.</summary>
+        public static bool IsAvailable => Available;
+
+        private static void Require()
+        {
+            if (!Available)
+            {
+                throw new InvalidOperationException(
+                    "libntsrocq is not available. Build it with `make -C oracle ffi` " +
+                    "in NetTopologySuite.Proofs, or put the native library on the loader path.");
+            }
+        }
+
+        // ---- Phase 0: orientation ------------------------------------------
+
+        /// <summary>Shewchuk Stage A filtered orientation of (p0, p1, q).</summary>
+        public static RocqOrientSign OrientSignFiltered(
+            double p0x, double p0y, double p1x, double p1y, double qx, double qy)
+        {
+            lock (Gate)
+            {
+                Require();
+                return (RocqOrientSign)RocqNativeMethods.nts_rocq_orient_sign_filtered(
+                    p0x, p0y, p1x, p1y, qx, qy);
+            }
+        }
+
+        /// <summary>Unfiltered sign of the raw determinant. NOT robust; for
+        /// differential testing against the filtered predicate.</summary>
+        public static RocqOrientSign OrientSignNaive(
+            double p0x, double p0y, double p1x, double p1y, double qx, double qy)
+        {
+            lock (Gate)
+            {
+                return (RocqOrientSign)RocqNativeMethods.nts_rocq_orient_sign_naive(
+                    p0x, p0y, p1x, p1y, qx, qy);
+            }
+        }
+
+        /// <summary>EXACT orientation sign over the full binary64 plane
+        /// (Orient_b64_exact_full.v, soundness Qed with no magnitude
+        /// restriction) — the escalation path for
+        /// <see cref="RocqOrientSign.Uncertain"/>.  Returns Pos/Neg/Zero for
+        /// finite inputs, Nan if any input is NaN or infinite; never
+        /// Uncertain.  Arbitrary-precision integer arithmetic: call it on the
+        /// Uncertain path, not as the primary predicate.</summary>
+        public static RocqOrientSign OrientSignExact(
+            double p0x, double p0y, double p1x, double p1y, double qx, double qy)
+        {
+            lock (Gate)
+            {
+                return (RocqOrientSign)RocqNativeMethods.nts_rocq_orient_sign_exact(
+                    p0x, p0y, p1x, p1y, qx, qy);
+            }
+        }
+
+        /// <summary>The raw binary64 orientation determinant.</summary>
+        public static double Orient2D(
+            double p0x, double p0y, double p1x, double p1y, double qx, double qy)
+        {
+            lock (Gate)
+            {
+                return RocqNativeMethods.nts_rocq_orient2d(p0x, p0y, p1x, p1y, qx, qy);
+            }
+        }
+
+        // ---- Phase 1: segment intersection ---------------------------------
+
+        public static RocqIntersectSign IntersectSignFiltered(
+            double p0x, double p0y, double p1x, double p1y,
+            double q0x, double q0y, double q1x, double q1y)
+        {
+            lock (Gate)
+            {
+                return (RocqIntersectSign)RocqNativeMethods.nts_rocq_intersect_sign_filtered(
+                    p0x, p0y, p1x, p1y, q0x, q0y, q1x, q1y);
+            }
+        }
+
+        /// <summary>Option-wrapped intersection point; false leaves x/y NaN.</summary>
+        public static bool TryIntersectPoint(
+            double p0x, double p0y, double p1x, double p1y,
+            double q0x, double q0y, double q1x, double q1y,
+            out double x, out double y)
+        {
+            lock (Gate)
+            {
+                return RocqNativeMethods.nts_rocq_intersect_point(
+                    p0x, p0y, p1x, p1y, q0x, q0y, q1x, q1y, out x, out y) == 1;
+            }
+        }
+
+        /// <summary>Total coordinate projections, computed unconditionally.</summary>
+        public static void IntersectPointXy(
+            double p0x, double p0y, double p1x, double p1y,
+            double q0x, double q0y, double q1x, double q1y,
+            out double x, out double y)
+        {
+            lock (Gate)
+            {
+                RocqNativeMethods.nts_rocq_intersect_point_xy(
+                    p0x, p0y, p1x, p1y, q0x, q0y, q1x, q1y, out x, out y);
+            }
+        }
+
+        // ---- Phase 2: snap rounding ----------------------------------------
+
+        public static bool PassesThroughHotPixel(
+            double p0x, double p0y, double p1x, double p1y, double cx, double cy)
+        {
+            lock (Gate)
+            {
+                return RocqNativeMethods.nts_rocq_passes_through_hot_pixel(
+                    p0x, p0y, p1x, p1y, cx, cy) == 1;
+            }
+        }
+
+        public static bool PassesThroughHotPixelHalfOpen(
+            double p0x, double p0y, double p1x, double p1y, double cx, double cy)
+        {
+            lock (Gate)
+            {
+                return RocqNativeMethods.nts_rocq_passes_through_hot_pixel_halfopen(
+                    p0x, p0y, p1x, p1y, cx, cy) == 1;
+            }
+        }
+
+        /// <summary>Round half to even onto the unit grid.</summary>
+        public static double SnapCoord(double x)
+        {
+            lock (Gate)
+            {
+                return RocqNativeMethods.nts_rocq_snap_coord(x);
+            }
+        }
+
+        /// <summary>Snap onto a power-of-two grid (value first, scale second --
+        /// the Coq argument order).</summary>
+        public static double SnapCoordScaled(double x, double scale)
+        {
+            lock (Gate)
+            {
+                return RocqNativeMethods.nts_rocq_snap_coord_scaled(x, scale);
+            }
+        }
+
+        // ---- Phase 3: overlay labelling ------------------------------------
+
+        public static bool EdgeInResult(RocqBooleanOp op, bool inLeft, bool inRight)
+        {
+            lock (Gate)
+            {
+                int r = RocqNativeMethods.nts_rocq_edge_in_result(
+                    (int)op, inLeft ? 1 : 0, inRight ? 1 : 0);
+                if (r < 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(op));
+                }
+                return r == 1;
+            }
+        }
+
+        // ---- Phase 4: circular arcs ----------------------------------------
+
+        /// <summary>In-circle determinant: positive iff (a,b,c) is CCW and p is
+        /// strictly inside its circumcircle.</summary>
+        public static double InCircle(
+            double ax, double ay, double bx, double by,
+            double cx, double cy, double px, double py)
+        {
+            lock (Gate)
+            {
+                return RocqNativeMethods.nts_rocq_in_circle(ax, ay, bx, by, cx, cy, px, py);
+            }
+        }
+
+        /// <summary>SUFFICIENT condition only: true =&gt; the chord crosses the
+        /// arc's circumcircle. False is inconclusive.</summary>
+        public static bool ChordCrossesArcCircle(
+            double sx, double sy, double mx, double my, double ex, double ey,
+            double px, double py, double qx, double qy)
+        {
+            lock (Gate)
+            {
+                return RocqNativeMethods.nts_rocq_chord_crosses_arc_circle(
+                    sx, sy, mx, my, ex, ey, px, py, qx, qy) == 1;
+            }
+        }
+
+        /// <summary>Single-root Cramer projection; emits infinity/NaN on a
+        /// two-crossing line. Not an enumerator.</summary>
+        public static void ArcLineIntersectXy(
+            double sx, double sy, double mx, double my, double ex, double ey,
+            double px, double py, double qx, double qy,
+            out double x, out double y)
+        {
+            lock (Gate)
+            {
+                RocqNativeMethods.nts_rocq_arc_line_intersect_xy(
+                    sx, sy, mx, my, ex, ey, px, py, qx, qy, out x, out y);
+            }
+        }
+
+        /// <summary>SUFFICIENT condition only: true =&gt; the arc passes through
+        /// the hot pixel. False is inconclusive.</summary>
+        public static bool ArcPassesThroughHotPixel(
+            double sx, double sy, double mx, double my, double ex, double ey,
+            double cx, double cy, double scale)
+        {
+            lock (Gate)
+            {
+                return RocqNativeMethods.nts_rocq_arc_passes_through_hot_pixel(
+                    sx, sy, mx, my, ex, ey, cx, cy, scale) == 1;
+            }
+        }
+
+        // ---- Stage D building blocks ---------------------------------------
+
+        /// <summary>Error-free transformation: sum + err == x + y exactly.</summary>
+        public static void TwoSum(double x, double y, out double sum, out double err)
+        {
+            lock (Gate)
+            {
+                RocqNativeMethods.nts_rocq_two_sum(x, y, out sum, out err);
+            }
+        }
+
+        /// <summary>Grows an expansion by one component; returns the settled
+        /// components and the running carry.</summary>
+        public static double[] GrowExpansion(double q, double[] xs, out double qFinal)
+        {
+            if (xs == null)
+            {
+                throw new ArgumentNullException(nameof(xs));
+            }
+
+            var outH = new double[xs.Length];
+            int k;
+            lock (Gate)
+            {
+                k = RocqNativeMethods.nts_rocq_grow_expansion(
+                    q, xs, xs.Length, outH, outH.Length, out qFinal);
+            }
+            if (k < 0)
+            {
+                throw new InvalidOperationException("nts_rocq_grow_expansion failed");
+            }
+
+            var result = new double[k];
+            Array.Copy(outH, result, k);
+            return result;
+        }
+
+        // ---- Simplifier ------------------------------------------------------
+
+        /// <summary>Greedy perpendicular-distance simplifier. Input and output are
+        /// flat (x, y) pairs.</summary>
+        public static double[] SimplifyPerp(double eps, double[] xy)
+        {
+            if (xy == null)
+            {
+                throw new ArgumentNullException(nameof(xy));
+            }
+            if ((xy.Length & 1) != 0)
+            {
+                throw new ArgumentException("expected flat (x, y) pairs", nameof(xy));
+            }
+
+            int nPts = xy.Length / 2;
+            var outXy = new double[xy.Length];
+            int k;
+            lock (Gate)
+            {
+                k = RocqNativeMethods.nts_rocq_simplify_perp(eps, xy, nPts, outXy, nPts);
+            }
+            if (k < 0)
+            {
+                throw new InvalidOperationException("nts_rocq_simplify_perp failed");
+            }
+
+            var result = new double[2 * k];
+            Array.Copy(outXy, result, 2 * k);
+            return result;
+        }
+    }
+}

--- a/src/NetTopologySuite/Algorithm/Construct/LargestEmptyCircle.cs
+++ b/src/NetTopologySuite/Algorithm/Construct/LargestEmptyCircle.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// AI-drafted, human-reviewed. Assisted-by: Cursor Grok 4.6
+// Port of JTS f76d2245.
+
+using System;
 using NetTopologySuite.Algorithm.Locate;
 using NetTopologySuite.Geometries;
 using NetTopologySuite.Operation.Distance;
@@ -9,7 +12,8 @@ namespace NetTopologySuite.Algorithm.Construct
 {
     /// <summary>
     /// Constructs the Largest Empty Circle for a set
-    /// of obstacle geometries, up to a given accuracy distance tolerance.
+    /// of obstacle geometries, up to a given accuracy distance tolerance
+    /// (which can be specified or determined automatically).
     /// The obstacles may be any combination of point, linear and polygonal geometries.
     /// <para/>
     /// The Largest Empty Circle (LEC) is the largest circle
@@ -105,6 +109,9 @@ namespace NetTopologySuite.Algorithm.Construct
         }
 
 
+        // Empirically determined to balance accuracy and speed.
+        private const double AutoToleranceFraction = 0.001;
+
         private readonly Geometry _obstacles;
         private readonly Geometry _boundary;
         private readonly double _tolerance;
@@ -143,7 +150,20 @@ namespace NetTopologySuite.Algorithm.Construct
         /// </summary>
         /// <param name="obstacles">A non-empty geometry representing the obstacles (points and lines)</param>
         /// <param name="boundary">A polygonal geometry to contain the LEC center (may be null or empty)</param>
-        /// <param name="tolerance">The distance tolerance for computing the center point (a positive value)</param>
+        public LargestEmptyCircle(Geometry obstacles, Geometry boundary)
+            : this(obstacles, boundary, 0.0)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of a Largest Empty Circle construction,
+        /// interior-disjoint to a set of obstacle geometries
+        /// and having its center within a polygonal boundary.
+        /// A zero tolerance automatically determines an approximation tolerance.
+        /// </summary>
+        /// <param name="obstacles">A non-empty geometry representing the obstacles (points and lines)</param>
+        /// <param name="boundary">A polygonal geometry to contain the LEC center (may be null or empty)</param>
+        /// <param name="tolerance">The distance tolerance for computing the center point (a non-negative value)</param>
         public LargestEmptyCircle(Geometry obstacles, Geometry boundary, double tolerance)
         {
             if (obstacles == null || obstacles.IsEmpty)
@@ -153,9 +173,9 @@ namespace NetTopologySuite.Algorithm.Construct
             if (boundary != null && !(boundary is IPolygonal)) {
                 throw new ArgumentException("Boundary must be polygonal", nameof(boundary));
             }
-            if (tolerance <= 0)
+            if (tolerance < 0)
             {
-                throw new ArgumentException(string.Format("Accuracy tolerance is non-positive: {0:R}", tolerance), nameof(tolerance));
+                throw new ArgumentException(string.Format("Accuracy tolerance is negative: {0:R}", tolerance), nameof(tolerance));
             }
             _obstacles = obstacles;
             _boundary = boundary;
@@ -341,15 +361,19 @@ namespace NetTopologySuite.Algorithm.Construct
             if (cell.IsFullyOutside)
                 return false;
 
+            double requiredTol = _tolerance > 0
+                ? _tolerance
+                : _farthestCell.Distance * AutoToleranceFraction;
+
             /*
              * The cell is outside, but overlaps the boundary
              * so it may contain a point which should be checked.
-             * This is only the case if the potential overlap distance 
+             * This is only the case if the potential overlap distance
              * is larger than the tolerance.
              */
             if (cell.IsOutside)
             {
-                bool isOverlapSignificant = cell.MaxDistance > _tolerance;
+                bool isOverlapSignificant = cell.MaxDistance > requiredTol;
                 return isOverlapSignificant;
             }
 
@@ -359,7 +383,7 @@ namespace NetTopologySuite.Algorithm.Construct
              * (up to tolerance).
              */
             double potentialIncrease = cell.MaxDistance - _farthestCell.Distance;
-            return potentialIncrease > _tolerance;
+            return potentialIncrease > requiredTol;
         }
 
         /// <summary>

--- a/src/NetTopologySuite/Algorithm/Construct/MaximumInscribedCircle.cs
+++ b/src/NetTopologySuite/Algorithm/Construct/MaximumInscribedCircle.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// AI-drafted, human-reviewed. Assisted-by: Cursor Grok 4.6
+// Port of JTS f76d2245.
+
+using System;
 using NetTopologySuite.Algorithm.Locate;
 using NetTopologySuite.Geometries;
 using NetTopologySuite.Operation.Distance;
@@ -9,7 +12,8 @@ namespace NetTopologySuite.Algorithm.Construct
 {
     /// <summary>
     /// Constructs the Maximum Inscribed Circle for a
-    /// polygonal <see cref="Geometry"/>, up to a specified tolerance.
+    /// polygonal <see cref="Geometry"/>, up to a specified tolerance
+    /// (which can be specified or determined automatically).
     /// The Maximum Inscribed Circle is determined by a point in the interior of the area
     /// which has the farthest distance from the area boundary,
     /// along with a boundary point at that distance.
@@ -22,6 +26,13 @@ namespace NetTopologySuite.Algorithm.Construct
     /// The radius length of the Maximum Inscribed Circle is a
     /// measure of how "narrow" a polygon is. It is the
     /// distance at which the negative buffer becomes empty.
+    /// The class supports testing whether a polygon is "narrower"
+    /// than a specified distance via
+    /// <see cref="IsRadiusWithin(Geometry, double)"/> or
+    /// <see cref="IsRadiusWithin(double)"/>.
+    /// Testing for the maximum radius is generally much faster
+    /// than computing the actual radius value, since short-circuiting
+    /// is used to limit the approximation iterations.
     /// <para/>
     /// The class supports polygons with holes and multipolygons.
     /// <para/>
@@ -41,6 +52,23 @@ namespace NetTopologySuite.Algorithm.Construct
     /// <see cref="Centroid"/>
     public class MaximumInscribedCircle
     {
+        // Empirically determined to balance accuracy and speed.
+        private const double AutoToleranceFraction = 0.001;
+        // Used for IsRadiusWithin.
+        private const double MaxRadiusFraction = 0.0001;
+
+        /// <summary>
+        /// Computes the center point of the Maximum Inscribed Circle
+        /// of a polygonal geometry.
+        /// </summary>
+        /// <param name="polygonal">A polygonal geometry</param>
+        /// <returns>The center point of the maximum inscribed circle</returns>
+        public static Point GetCenter(Geometry polygonal)
+        {
+            var mic = new MaximumInscribedCircle(polygonal);
+            return mic.GetCenter();
+        }
+
         /// <summary>
         /// Computes the center point of the Maximum Inscribed Circle
         /// of a polygonal geometry, up to a given tolerance distance.
@@ -52,6 +80,18 @@ namespace NetTopologySuite.Algorithm.Construct
         {
             var mic = new MaximumInscribedCircle(polygonal, tolerance);
             return mic.GetCenter();
+        }
+
+        /// <summary>
+        /// Computes a radius line of the Maximum Inscribed Circle
+        /// of a polygonal geometry.
+        /// </summary>
+        /// <param name="polygonal">A polygonal geometry</param>
+        /// <returns>A line from the center to a point on the circle</returns>
+        public static LineString GetRadiusLine(Geometry polygonal)
+        {
+            var mic = new MaximumInscribedCircle(polygonal);
+            return mic.GetRadiusLine();
         }
 
         /// <summary>
@@ -68,6 +108,21 @@ namespace NetTopologySuite.Algorithm.Construct
         }
 
         /// <summary>
+        /// Tests if the radius of the maximum inscribed circle
+        /// is no longer than the specified distance.
+        /// The approximation tolerance is determined automatically
+        /// as a fraction of the <paramref name="maxRadius"/> value.
+        /// </summary>
+        /// <param name="polygonal">A polygonal geometry</param>
+        /// <param name="maxRadius">The radius value to test</param>
+        /// <returns><c>true</c> if the max in-circle radius is no longer than the max radius</returns>
+        public static bool IsRadiusWithin(Geometry polygonal, double maxRadius)
+        {
+            var mic = new MaximumInscribedCircle(polygonal);
+            return mic.IsRadiusWithin(maxRadius);
+        }
+
+        /// <summary>
         /// Computes the maximum number of iterations allowed.
         /// Uses a heuristic based on the size of the input geometry
         /// and the tolerance distance.
@@ -81,7 +136,8 @@ namespace NetTopologySuite.Algorithm.Construct
         internal static long ComputeMaximumIterations(Geometry geom, double toleranceDist)
         {
             double diam = geom.EnvelopeInternal.Diameter;
-            double ncells = diam / toleranceDist;
+            double tolDist = toleranceDist <= 0 ? 0.5 * diam * AutoToleranceFraction : toleranceDist;
+            double ncells = diam / tolDist;
             //-- Using log of ncells allows control over number of iterations
             int factor = (int)Math.Log(ncells);
             if (factor < 1) factor = 1;
@@ -89,7 +145,7 @@ namespace NetTopologySuite.Algorithm.Construct
         }
 
         private readonly Geometry _inputGeom;
-        private readonly double _tolerance;
+        private double _tolerance;
 
         private readonly GeometryFactory _factory;
         private readonly IndexedPointInAreaLocator _ptLocater;
@@ -99,19 +155,32 @@ namespace NetTopologySuite.Algorithm.Construct
         private Coordinate _radiusPt;
         private Point _centerPoint;
         private Point _radiusPoint;
+        private double _maximumRadius = -1;
 
         /// <summary>
         /// Creates a new instance of a Maximum Inscribed Circle computation.
+        /// A zero tolerance automatically determines an approximation tolerance.
+        /// </summary>
+        /// <param name="polygonal">An areal geometry</param>
+        /// <exception cref="ArgumentException">Thrown if the input geometry is non-polygonal or empty</exception>
+        public MaximumInscribedCircle(Geometry polygonal)
+            : this(polygonal, 0.0)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of a Maximum Inscribed Circle computation.
+        /// A zero tolerance automatically determines an approximation tolerance.
         /// </summary>
         /// <param name="polygonal">An areal geometry</param>
         /// <param name="tolerance">The distance tolerance for computing the centre point
-        /// (must be positive)</param>
-        /// <exception cref="ArgumentOutOfRangeException">Thrown if the tolerance is non-positive</exception>
+        /// (must be non-negative)</param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if the tolerance is negative</exception>
         /// <exception cref="ArgumentException">Thrown if the input geometry is non-polygonal or empty</exception>
         public MaximumInscribedCircle(Geometry polygonal, double tolerance)
         {
-            if (tolerance <= 0)
-                throw new ArgumentOutOfRangeException(nameof(tolerance), "Tolerance must be positive");
+            if (tolerance < 0)
+                throw new ArgumentOutOfRangeException(nameof(tolerance), "Tolerance must be non-negative");
 
             if (!(polygonal is IPolygonal))
                 throw new ArgumentException("Input geometry must be a Polygon or MultiPolygon");
@@ -124,6 +193,37 @@ namespace NetTopologySuite.Algorithm.Construct
             _tolerance = tolerance;
             _ptLocater = new IndexedPointInAreaLocator(polygonal);
             _indexedDistance = new IndexedFacetDistance(polygonal.Boundary);
+        }
+
+        /// <summary>
+        /// Tests if the radius of the maximum inscribed circle
+        /// is no longer than the specified distance.
+        /// This method determines the distance tolerance automatically
+        /// as a fraction of the <paramref name="maxRadius"/> value.
+        /// After this method is called the center and radius
+        /// points provide locations demonstrating where
+        /// the radius exceeds the specified maximum.
+        /// </summary>
+        /// <param name="maxRadius">The (non-negative) radius value to test</param>
+        /// <returns><c>true</c> if the max in-circle radius is no longer than the max radius</returns>
+        public bool IsRadiusWithin(double maxRadius)
+        {
+            if (maxRadius < 0)
+                throw new ArgumentOutOfRangeException(nameof(maxRadius), "Radius length must be non-negative");
+            // Handle 0 corner case, to provide maximum domain.
+            if (maxRadius == 0)
+                return false;
+            _maximumRadius = maxRadius;
+
+            var env = _inputGeom.EnvelopeInternal;
+            double maxDiam = 2 * _maximumRadius;
+            if (env.Width < maxDiam || env.Height < maxDiam)
+                return true;
+
+            _tolerance = maxRadius * MaxRadiusFraction;
+            Compute();
+            double radius = _centerPt.Distance(_radiusPt);
+            return radius <= _maximumRadius;
         }
 
         /// <summary>
@@ -215,33 +315,45 @@ namespace NetTopologySuite.Algorithm.Construct
                 //Console.WriteLine(_factory.ToGeometry(cell.Envelope));
                 //Console.WriteLine($"{iter}] Dist: {cell.Distance} size: {cell.HSide}");
 
-                //-- if cell must be closer than furthest, terminate since all remaining cells in queue are even closer. 
-                if (cell.MaxDistance < farthestCell.Distance)
-                    break;
-
                 // update the circle center cell if the candidate is further from the boundary
                 if (cell.Distance > farthestCell.Distance)
                 {
                     farthestCell = cell;
                 }
+
+                // Search termination when checking IsRadiusWithin predicate.
+                if (_maximumRadius >= 0)
+                {
+                    if (farthestCell.Distance > _maximumRadius)
+                        break;
+                    if (cell.MaxDistance < _maximumRadius)
+                        break;
+                }
+
                 /*
                  * Refine this cell if the potential distance improvement
                  * is greater than the required tolerance.
                  * Otherwise the cell is pruned (not investigated further),
                  * since no point in it is further than
-                 * the current farthest distance.
+                 * the current farthest distance (up to tolerance).
+                 *
+                 * The tolerance can be automatically determined
+                 * as a fraction of the current farthest distance.
                  */
+                double requiredTol = _tolerance > 0
+                    ? _tolerance
+                    : farthestCell.Distance * AutoToleranceFraction;
+
                 double potentialIncrease = cell.MaxDistance - farthestCell.Distance;
-                if (potentialIncrease > _tolerance)
-                {
-                    // split the cell into four sub-cells
-                    double h2 = cell.HSide / 2;
-                    cellQueue.Add(CreateCell(cell.X - h2, cell.Y - h2, h2));
-                    cellQueue.Add(CreateCell(cell.X + h2, cell.Y - h2, h2));
-                    cellQueue.Add(CreateCell(cell.X - h2, cell.Y + h2, h2));
-                    cellQueue.Add(CreateCell(cell.X + h2, cell.Y + h2, h2));
-                    //totalCells += 4;
-                }
+                if (potentialIncrease < requiredTol)
+                    break;
+
+                // refine the cell into four sub-cells
+                double h2 = cell.HSide / 2;
+                cellQueue.Add(CreateCell(cell.X - h2, cell.Y - h2, h2));
+                cellQueue.Add(CreateCell(cell.X + h2, cell.Y - h2, h2));
+                cellQueue.Add(CreateCell(cell.X - h2, cell.Y + h2, h2));
+                cellQueue.Add(CreateCell(cell.X + h2, cell.Y + h2, h2));
             }
             // the farthest cell is the best approximation to the MIC center
             _centerCell = farthestCell;

--- a/src/NetTopologySuite/Algorithm/ExactCurve/AngleBetween.cs
+++ b/src/NetTopologySuite/Algorithm/ExactCurve/AngleBetween.cs
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// AI assistance disclosure:
+//   AI-drafted, human-reviewed. Assisted-by: Cursor Grok 4.6
+//   AI-generated portions dedicated to CC0-1.0; human curation BSD-3-Clause.
+
+using System;
+using NetTopologySuite.Geometries;
+
+namespace NetTopologySuite.Algorithm.ExactCurve
+{
+    /// <summary>
+    /// Sweep owner for <see cref="ExactCircularArc"/>: signed short via
+    /// <c>atan2(cross, dot)</c>, then mid-point long/short disambiguation.
+    /// </summary>
+    /// <remarks>
+    /// Maintainability: one place for the transcendental; callers must not
+    /// re-roll <c>% 2π</c> locally.
+    /// Soundness: relative <c>atan2(u×v, u·v)</c> does not collapse a tiny
+    /// crossing at the <c>±π</c> branch cut into a false full turn.
+        /// Performance: <see cref="SweepOf(double, double, Coordinate, Coordinate, Coordinate)"/>
+        /// is allocation-free.
+        /// Port of JTS <c>9797c2c4</c>.
+    /// </remarks>
+    public static class AngleBetween
+    {
+        public const double TwoPi = 2.0 * Math.PI;
+
+        public static double SignedShort(double ux, double uy, double vx, double vy)
+        {
+            return Math.Atan2(ux * vy - uy * vx, ux * vx + uy * vy);
+        }
+
+        public static double SignedShort(double cx, double cy, Coordinate from, Coordinate to)
+        {
+            return SignedShort(from.X - cx, from.Y - cy, to.X - cx, to.Y - cy);
+        }
+
+        public static DirectedSweep Through(double cx, double cy,
+            Coordinate start, Coordinate mid, Coordinate end)
+        {
+            return FromShorts(
+                SignedShort(cx, cy, start, end),
+                SignedShort(cx, cy, start, mid));
+        }
+
+        public static double SweepOf(double cx, double cy,
+            Coordinate start, Coordinate mid, Coordinate end)
+        {
+            return SweepFromShorts(
+                SignedShort(cx, cy, start, end),
+                SignedShort(cx, cy, start, mid));
+        }
+
+        public static double Travelled(bool ccw, double ux, double uy, double px, double py)
+        {
+            double s = SignedShort(ux, uy, px, py);
+            return ccw ? NormalizePositive(s) : NormalizePositive(-s);
+        }
+
+        public static double NormalizePositive(double angle)
+        {
+            angle %= TwoPi;
+            if (angle < 0.0) angle += TwoPi;
+            return angle;
+        }
+
+        public readonly struct DirectedSweep
+        {
+            public DirectedSweep(bool ccw, double radians)
+            {
+                IsCcw = ccw;
+                Radians = radians;
+            }
+
+            public bool IsCcw { get; }
+
+            public double Radians { get; }
+
+            public double Signed => IsCcw ? Radians : -Radians;
+        }
+
+        private static DirectedSweep FromShorts(double shortSE, double shortSM)
+        {
+            bool ccw = CcwFromShorts(shortSE, shortSM);
+            return new DirectedSweep(ccw, SweepFromShorts(shortSE, shortSM));
+        }
+
+        private static bool CcwFromShorts(double shortSE, double shortSM)
+        {
+            return NormalizePositive(shortSM) < NormalizePositive(shortSE);
+        }
+
+        private static double SweepFromShorts(double shortSE, double shortSM)
+        {
+            double s = CcwFromShorts(shortSE, shortSM)
+                ? NormalizePositive(shortSE)
+                : NormalizePositive(-shortSE);
+            return s == 0.0 ? TwoPi : s;
+        }
+    }
+}

--- a/src/NetTopologySuite/Algorithm/ExactCurve/AngleBetween.cs
+++ b/src/NetTopologySuite/Algorithm/ExactCurve/AngleBetween.cs
@@ -18,9 +18,9 @@ namespace NetTopologySuite.Algorithm.ExactCurve
     /// re-roll <c>% 2π</c> locally.
     /// Soundness: relative <c>atan2(u×v, u·v)</c> does not collapse a tiny
     /// crossing at the <c>±π</c> branch cut into a false full turn.
-        /// Performance: <see cref="SweepOf(double, double, Coordinate, Coordinate, Coordinate)"/>
-        /// is allocation-free.
-        /// Port of JTS <c>9797c2c4</c>.
+    /// Performance: <see cref="SweepOf(double, double, Coordinate, Coordinate, Coordinate)"/>
+    /// is allocation-free.
+    /// Port of JTS <c>9797c2c4</c>.
     /// </remarks>
     public static class AngleBetween
     {

--- a/src/NetTopologySuite/Algorithm/ExactCurve/ExactCircularArc.cs
+++ b/src/NetTopologySuite/Algorithm/ExactCurve/ExactCircularArc.cs
@@ -1,0 +1,304 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// AI assistance disclosure:
+//   AI-drafted, human-reviewed. Assisted-by: Cursor Grok 4.6
+//   AI-generated portions dedicated to CC0-1.0; human curation BSD-3-Clause.
+
+using System;
+using NetTopologySuite.Geometries;
+
+namespace NetTopologySuite.Algorithm.ExactCurve
+{
+    /// <summary>
+    /// Privileged ExactCurve primitive: one 3-control circular window.
+    /// Closed-form <c>r·θ</c>, chord ≤ arc, in-arc, segment area,
+    /// arc-length centroid, <see cref="PointAt"/>.
+    /// </summary>
+    /// <remarks>
+    /// Maintainability: circumcircle lives here so callers do not copy the
+    /// determinant; colinear triples degrade to an exact chord.
+    /// Soundness: <see cref="Length"/> and <see cref="PointAt"/> never densify.
+    /// Performance: static <see cref="LengthOf"/> is one hypot plus one multiply.
+    /// Port of JTS <c>9797c2c4</c>.
+    /// </remarks>
+    public sealed class ExactCircularArc : IExactCurve
+    {
+        private const double DefaultToleranceFraction = 0.01;
+
+        private readonly Coordinate _start;
+        private readonly Coordinate _mid;
+        private readonly Coordinate _end;
+        private readonly double _cx;
+        private readonly double _cy;
+        private readonly double _r;
+        private readonly double _a0;
+        private readonly bool _ccw;
+        private readonly double _sweep;
+        private readonly bool _arc;
+
+        public ExactCircularArc(Coordinate start, Coordinate mid, Coordinate end)
+        {
+            _start = start.Copy();
+            _mid = mid.Copy();
+            _end = end.Copy();
+            if (!TryCircumcircle(start, mid, end, out _cx, out _cy, out _r))
+            {
+                _a0 = 0.0;
+                _ccw = true;
+                _sweep = 0.0;
+                _arc = false;
+                return;
+            }
+            _a0 = Math.Atan2(start.Y - _cy, start.X - _cx);
+            var sw = AngleBetween.Through(_cx, _cy, start, mid, end);
+            _ccw = sw.IsCcw;
+            _sweep = sw.Radians;
+            _arc = true;
+        }
+
+        /// <summary>Allocation-light <c>r·θ</c> (or chord).</summary>
+        public static double LengthOf(Coordinate start, Coordinate mid, Coordinate end)
+        {
+            if (!TryCircumcircle(start, mid, end, out double cx, out double cy, out double r))
+            {
+                return start.Distance(end);
+            }
+            return r * AngleBetween.SweepOf(cx, cy, start, mid, end);
+        }
+
+        public Coordinate Start => _start;
+
+        public Coordinate Mid => _mid;
+
+        public Coordinate End => _end;
+
+        public bool IsArc => _arc;
+
+        public bool IsCcw => _ccw;
+
+        public double Radius => _r;
+
+        public Coordinate Center => _arc ? new Coordinate(_cx, _cy) : null;
+
+        /// <summary>Central angle in <c>(0, 2π]</c>; <c>0</c> on a chord fallback.</summary>
+        public double Sweep => _sweep;
+
+        public double Length => _arc ? _r * _sweep : _start.Distance(_end);
+
+        public double ChordLength => _start.Distance(_end);
+
+        public bool IsExact => true;
+
+        public Coordinate PointAt(double t)
+        {
+            if (double.IsNaN(t) || double.IsInfinity(t) || t < 0.0 || t > 1.0)
+            {
+                throw new ArgumentException("t must be in [0,1]: " + t, nameof(t));
+            }
+            if (t == 0.0)
+            {
+                return _start.Copy();
+            }
+            if (t == 1.0)
+            {
+                return _end.Copy();
+            }
+            if (!_arc)
+            {
+                return new Coordinate(
+                    _start.X + t * (_end.X - _start.X),
+                    _start.Y + t * (_end.Y - _start.Y));
+            }
+            double ang = _a0 + (_ccw ? _sweep : -_sweep) * t;
+            return new Coordinate(_cx + _r * Math.Cos(ang), _cy + _r * Math.Sin(ang));
+        }
+
+        /// <summary>Documented densify shim. Not used by <see cref="Length"/> or <see cref="PointAt"/>.</summary>
+        public Geometry ToLinear(double tolerance)
+        {
+            if (tolerance < 0.0)
+            {
+                throw new ArgumentException("tolerance must be non-negative: " + tolerance, nameof(tolerance));
+            }
+            if (!_arc)
+            {
+                return GeometryFactory.Default.CreateLineString(new[] { _start.Copy(), _end.Copy() });
+            }
+            double eps = tolerance == 0.0 ? _r * DefaultToleranceFraction : tolerance;
+            int segments = SegmentCount(_r, _sweep, eps);
+            double delta = _sweep / segments;
+            if (!_ccw)
+            {
+                delta = -delta;
+            }
+            var pts = new Coordinate[segments + 1];
+            pts[0] = _start.Copy();
+            for (int i = 1; i < segments; i++)
+            {
+                double ang = _a0 + i * delta;
+                pts[i] = new Coordinate(_cx + _r * Math.Cos(ang), _cy + _r * Math.Sin(ang));
+            }
+            pts[segments] = _end.Copy();
+            return GeometryFactory.Default.CreateLineString(pts);
+        }
+
+        public bool ChordLeArc()
+        {
+            double chord = ChordLength;
+            if (!_arc)
+            {
+                return true;
+            }
+            double arcLen = _r * _sweep;
+            if (chord <= arcLen)
+            {
+                return true;
+            }
+            double chordFromSweep = 2.0 * _r * Math.Sin(0.5 * _sweep);
+            double bound = Math.Max(arcLen, chordFromSweep);
+            return chord <= bound + Ulp(Math.Max(bound, chord));
+        }
+
+        public bool InArc(Coordinate p, double radialTol)
+        {
+            if (p == null)
+            {
+                return false;
+            }
+            if (!_arc)
+            {
+                return OnSegment(p, _start, _end, radialTol);
+            }
+            double dx = p.X - _cx;
+            double dy = p.Y - _cy;
+            double d2 = dx * dx + dy * dy;
+            double r2 = _r * _r;
+            double tol2 = radialTol * (2.0 * _r + radialTol);
+            if (Math.Abs(d2 - r2) > tol2)
+            {
+                return false;
+            }
+            return OnSweep(p);
+        }
+
+        /// <summary>Circular-segment area <c>r²/2 · (θ − sin θ)</c>. Zero on a chord.</summary>
+        public double CircularSegmentArea()
+        {
+            if (!_arc)
+            {
+                return 0.0;
+            }
+            return 0.5 * _r * _r * (_sweep - Math.Sin(_sweep));
+        }
+
+        /// <summary>
+        /// Wire (arc-length) centroid. One signed-sweep formula for both
+        /// orientations: <c>(r/δ) (sin a1 − sin a0, −cos a1 + cos a0)</c>.
+        /// </summary>
+        public Coordinate ArcLengthCentroid()
+        {
+            if (!_arc)
+            {
+                return new Coordinate(0.5 * (_start.X + _end.X), 0.5 * (_start.Y + _end.Y));
+            }
+            if (_sweep == 0.0)
+            {
+                return _start.Copy();
+            }
+            double signed = _ccw ? _sweep : -_sweep;
+            double a1 = _a0 + signed;
+            double k = _r / signed;
+            return new Coordinate(
+                _cx + k * (Math.Sin(a1) - Math.Sin(_a0)),
+                _cy + k * (-Math.Cos(a1) + Math.Cos(_a0)));
+        }
+
+        internal static bool TryCircumcircle(Coordinate a, Coordinate b, Coordinate c,
+            out double cx, out double cy, out double r)
+        {
+            cx = double.NaN;
+            cy = double.NaN;
+            r = 0.0;
+            if (Orientation.Index(a, b, c) == OrientationIndex.Collinear)
+            {
+                return false;
+            }
+            double ax = a.X, ay = a.Y;
+            double bx = b.X, by = b.Y;
+            double cxp = c.X, cyp = c.Y;
+            double d = 2.0 * (ax * (by - cyp) + bx * (cyp - ay) + cxp * (ay - by));
+            if (d == 0.0)
+            {
+                return false;
+            }
+            double a2 = ax * ax + ay * ay;
+            double b2 = bx * bx + by * by;
+            double c2 = cxp * cxp + cyp * cyp;
+            cx = (a2 * (by - cyp) + b2 * (cyp - ay) + c2 * (ay - by)) / d;
+            cy = (a2 * (cxp - bx) + b2 * (ax - cxp) + c2 * (bx - ax)) / d;
+            r = Math.Sqrt((ax - cx) * (ax - cx) + (ay - cy) * (ay - cy));
+            return !double.IsNaN(r) && !double.IsInfinity(r) && r != 0.0;
+        }
+
+        internal static int SegmentCount(double radius, double sweep, double tolerance)
+        {
+            if (tolerance >= radius)
+            {
+                return 1;
+            }
+            double thetaMax = 2.0 * Math.Acos(1.0 - tolerance / radius);
+            if (double.IsNaN(thetaMax) || double.IsInfinity(thetaMax) || thetaMax <= 0.0)
+            {
+                return 1;
+            }
+            int n = (int)Math.Ceiling(sweep / thetaMax);
+            return n < 1 ? 1 : n;
+        }
+
+        private bool OnSweep(Coordinate p)
+        {
+            if (!_arc)
+            {
+                return false;
+            }
+            double travelled = AngleBetween.Travelled(_ccw,
+                _start.X - _cx, _start.Y - _cy, p.X - _cx, p.Y - _cy);
+            return travelled <= _sweep + Ulp(_sweep);
+        }
+
+        private static bool OnSegment(Coordinate p, Coordinate a, Coordinate b, double tol)
+        {
+            double dx = b.X - a.X;
+            double dy = b.Y - a.Y;
+            double len2 = dx * dx + dy * dy;
+            if (len2 == 0.0)
+            {
+                return p.Distance(a) <= tol;
+            }
+            double t = ((p.X - a.X) * dx + (p.Y - a.Y) * dy) / len2;
+            if (t < 0.0)
+            {
+                t = 0.0;
+            }
+            else if (t > 1.0)
+            {
+                t = 1.0;
+            }
+            double px = a.X + t * dx - p.X;
+            double py = a.Y + t * dy - p.Y;
+            return px * px + py * py <= tol * tol;
+        }
+
+        internal static double Ulp(double value)
+        {
+            if (double.IsNaN(value) || double.IsInfinity(value))
+            {
+                return value;
+            }
+            double abs = Math.Abs(value);
+            long bits = BitConverter.DoubleToInt64Bits(abs);
+            double next = BitConverter.Int64BitsToDouble(bits + 1);
+            return next - abs;
+        }
+    }
+}

--- a/src/NetTopologySuite/Algorithm/ExactCurve/IExactCurve.cs
+++ b/src/NetTopologySuite/Algorithm/ExactCurve/IExactCurve.cs
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// AI assistance disclosure:
+//   AI-drafted, human-reviewed. Assisted-by: Cursor Grok 4.6
+//   AI-generated portions dedicated to CC0-1.0; human curation BSD-3-Clause.
+
+using NetTopologySuite.Geometries;
+
+namespace NetTopologySuite.Algorithm.ExactCurve
+{
+    /// <summary>
+    /// Thin ExactCurve protocol. Only Exact* value types implement it.
+    /// </summary>
+    /// <remarks>
+    /// Maintainability: do not add methods; do not introduce a rich base.
+    /// Soundness: <see cref="IsExact"/> implementations must not densify from
+    /// <see cref="Length"/> or <see cref="PointAt"/>.
+    /// Performance: closed-form cells stay allocation-light.
+    /// </remarks>
+    public interface IExactCurve
+    {
+        Coordinate Start { get; }
+
+        Coordinate End { get; }
+
+        double Length { get; }
+
+        /// <summary>Point at arc-length fraction <c>t</c> in [0, 1].</summary>
+        Coordinate PointAt(double t);
+
+        /// <summary>Documented densify shim. The only allowed linearisation path.</summary>
+        Geometry ToLinear(double tolerance);
+
+        bool IsExact { get; }
+    }
+}

--- a/src/NetTopologySuite/CompatibilitySuppressions.xml
+++ b/src/NetTopologySuite/CompatibilitySuppressions.xml
@@ -1,0 +1,41 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
+<!--
+  CP0012 on LineString.IsClosed: the member changes from 'virtual' (newslot) to
+  'override' (reuseslot) because the abstract Curve base class now declares
+  IsClosed for all curves. Virtual dispatch through a LineString reference and
+  existing external overrides of LineString.IsClosed keep working - the slot is
+  resolved through the inheritance chain at JIT time - so the change is
+  binary-compatible in practice. It cannot be expressed differently: an
+  override cannot simultaneously create a new slot.
+-->
+<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Suppression>
+    <DiagnosticId>CP0012</DiagnosticId>
+    <Target>M:NetTopologySuite.Geometries.LineString.get_IsClosed</Target>
+    <Left>lib/netstandard2.0/NetTopologySuite.dll</Left>
+    <Right>lib/netstandard2.0/NetTopologySuite.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0012</DiagnosticId>
+    <Target>P:NetTopologySuite.Geometries.LineString.IsClosed</Target>
+    <Left>lib/netstandard2.0/NetTopologySuite.dll</Left>
+    <Right>lib/netstandard2.0/NetTopologySuite.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0012</DiagnosticId>
+    <Target>M:NetTopologySuite.Geometries.LineString.get_IsClosed</Target>
+    <Left>lib/netstandard2.1/NetTopologySuite.dll</Left>
+    <Right>lib/netstandard2.1/NetTopologySuite.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0012</DiagnosticId>
+    <Target>P:NetTopologySuite.Geometries.LineString.IsClosed</Target>
+    <Left>lib/netstandard2.1/NetTopologySuite.dll</Left>
+    <Right>lib/netstandard2.1/NetTopologySuite.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+</Suppressions>

--- a/src/NetTopologySuite/Geometries/Curve.cs
+++ b/src/NetTopologySuite/Geometries/Curve.cs
@@ -1,0 +1,58 @@
+using System;
+
+namespace NetTopologySuite.Geometries
+{
+    /// <summary>
+    /// Abstract base class for geometries that have a <c>Dimension</c> of
+    /// <see cref="Geometries.Dimension.Curve"/> and consist of <b>only</b> <c>1</c> component.
+    /// </summary>
+    [Serializable]
+    public abstract class Curve : Geometry, ILineal
+    {
+        /// <summary>
+        /// Creates an instance of this class
+        /// </summary>
+        /// <param name="factory">The factory creating this <c>Curve</c></param>
+        protected Curve(GeometryFactory factory) : base(factory)
+        {
+        }
+
+        /// <inheritdoc cref="Geometry.Dimension"/>
+        public sealed override Dimension Dimension => Dimension.Curve;
+
+
+        /// <inheritdoc cref="Geometry.BoundaryDimension"/>
+        public override Dimension BoundaryDimension
+        {
+            get
+            {
+                if (IsClosed)
+                {
+                    return Dimension.False;
+                }
+                return Dimension.Point;
+            }
+        }
+
+        /// <summary>
+        /// Gets a value indicating if this <c>Curve</c> forms a ring.
+        /// </summary>
+        public bool IsRing { get => IsClosed & IsSimple; }
+
+        /// <summary>
+        /// Gets a value indicating that this <c>Curve</c> is closed.<br/>
+        /// A curve is closed if <c><see cref="StartPoint"/> == <see cref="EndPoint"/></c>.
+        /// </summary>
+        public abstract bool IsClosed { get; }
+
+        /// <summary>
+        /// Gets a value indicating the start point of this <c>CURVE</c>
+        /// </summary>
+        public abstract Point StartPoint { get; }
+
+        /// <summary>
+        /// Gets a value indicating the end point of this <c>CURVE</c>
+        /// </summary>
+        public abstract Point EndPoint { get; }
+    }
+}

--- a/src/NetTopologySuite/Geometries/Curves/CircularString.cs
+++ b/src/NetTopologySuite/Geometries/Curves/CircularString.cs
@@ -1,0 +1,295 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// AI assistance disclosure:
+//   AI-drafted, human-reviewed and curated. Per the same convention used for the
+//   companion JTS prototype at grootstebozewolf/jts#1, AI-generated portions are
+//   dedicated to CC0-1.0; human curation falls under the NTS BSD-3-Clause grant.
+//
+//   Assisted-by: Claude (Opus-4.7)
+//
+// Status: PLAYGROUND -- prototype of OGC SFA-CA CircularString on top of the
+// foundational Curve/Surface abstractions already on enhancement/curved.
+// Not for merge into develop without further design discussion -- see the PR
+// description for scope, decisions, and open questions.
+
+using System;
+using System.Collections.Generic;
+using NetTopologySuite.Algorithm;
+
+namespace NetTopologySuite.Geometries.Curves
+{
+    /// <summary>
+    /// An OGC SFA-CA <c>CircularString</c>: a sequence of circular arc segments,
+    /// each defined by three consecutive coordinates (start, point on arc, end).
+    /// </summary>
+    /// <remarks>
+    /// A <c>CircularString</c> with <c>2n + 1</c> coordinates encodes <c>n</c> arcs,
+    /// with adjacent arcs sharing endpoints.  An empty <c>CircularString</c> has zero
+    /// coordinates.
+    /// <para/>
+    /// This is a prototype.  In particular, <c>Length</c> and <c>Boundary</c> currently
+    /// fall back to chord-based computations (treating the control points as a polyline)
+    /// rather than analytical arc geometry; the inherited <see cref="Curve.IsClosed"/>
+    /// semantics still apply (start equals end).
+    /// </remarks>
+    [Serializable]
+    public class CircularString : Curve, ILinearizable<LineString>
+    {
+        /// <summary>The control points of the arcs.</summary>
+        private readonly CoordinateSequence _points;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CircularString"/> class.
+        /// </summary>
+        /// <param name="points">The coordinate sequence of control points</param>
+        /// <param name="factory">The geometry factory</param>
+        /// <exception cref="ArgumentException">
+        /// If the sequence has fewer than 3 points or an even number of points
+        /// (must be 0 or odd and at least 3).
+        /// </exception>
+        public CircularString(CoordinateSequence points, GeometryFactory factory) : base(factory)
+        {
+            if (points == null)
+            {
+                points = factory.CoordinateSequenceFactory.Create(0, Ordinates.XY);
+            }
+            if (points.Count != 0)
+            {
+                if (points.Count < 3)
+                {
+                    throw new ArgumentException(
+                        "A non-empty CircularString must have at least 3 control points " +
+                        "(start, on-arc, end of the first arc).", nameof(points));
+                }
+                if (points.Count % 2 == 0)
+                {
+                    throw new ArgumentException(
+                        "A CircularString must have an odd number of control points " +
+                        "(2n + 1 points encode n arcs).", nameof(points));
+                }
+            }
+            _points = points;
+        }
+
+        /// <summary>The control points of this <c>CircularString</c>.</summary>
+        public CoordinateSequence CoordinateSequence => _points;
+
+        /// <summary>The number of arc segments encoded by this <c>CircularString</c>.</summary>
+        public int NumArcs => _points.Count == 0 ? 0 : (_points.Count - 1) / 2;
+
+        /// <inheritdoc cref="Geometry.NumPoints"/>
+        public override int NumPoints => _points.Count;
+
+        /// <inheritdoc cref="Geometry.IsEmpty"/>
+        public override bool IsEmpty => _points.Count == 0;
+
+        /// <inheritdoc cref="Geometry.Coordinate"/>
+        public override Coordinate Coordinate => IsEmpty ? null : _points.GetCoordinate(0);
+
+        /// <inheritdoc cref="Geometry.Coordinates"/>
+        public override Coordinate[] Coordinates => _points.ToCoordinateArray();
+
+        /// <inheritdoc/>
+        public override double[] GetOrdinates(Ordinate ordinate)
+        {
+            if (IsEmpty) return new double[0];
+            var ordinateFlag = (Ordinates)(1 << (int)ordinate);
+            if ((_points.Ordinates & ordinateFlag) != ordinateFlag)
+            {
+                var nulls = new double[_points.Count];
+                for (int i = 0; i < nulls.Length; i++) nulls[i] = Coordinate.NullOrdinate;
+                return nulls;
+            }
+            var vals = new double[_points.Count];
+            for (int i = 0; i < _points.Count; i++) vals[i] = _points.GetOrdinate(i, (int)ordinate);
+            return vals;
+        }
+
+        /// <inheritdoc cref="Curve.StartPoint"/>
+        public override Point StartPoint =>
+            IsEmpty ? null : Factory.CreatePoint(_points.GetCoordinate(0));
+
+        /// <inheritdoc cref="Curve.EndPoint"/>
+        public override Point EndPoint =>
+            IsEmpty ? null : Factory.CreatePoint(_points.GetCoordinate(_points.Count - 1));
+
+        /// <inheritdoc cref="Curve.IsClosed"/>
+        public override bool IsClosed
+        {
+            get
+            {
+                if (IsEmpty) return false;
+                return _points.GetCoordinate(0).Equals2D(_points.GetCoordinate(_points.Count - 1));
+            }
+        }
+
+        /// <inheritdoc cref="Geometry.GeometryType"/>
+        public override string GeometryType => "CircularString";
+
+        /// <inheritdoc cref="Geometry.OgcGeometryType"/>
+        public override OgcGeometryType OgcGeometryType => OgcGeometryType.CircularString;
+
+        /// <summary>
+        /// Length approximated by summing arc-chord lengths.  Analytical arc-length
+        /// computation is tracked in the prototype roadmap.
+        /// </summary>
+        public override double Length => Algorithm.Length.OfLine(_points);
+
+        /// <summary>
+        /// The boundary of a curve per the Mod-2 rule: empty when the curve is empty
+        /// or closed, otherwise the two end points.
+        /// </summary>
+        /// <remarks>
+        /// <c>BoundaryOp</c> only special-cases <see cref="LineString"/> and
+        /// <see cref="MultiLineString"/>; calling it for curve types recurses into
+        /// <see cref="Geometry.Boundary"/> and stack-overflows.  Mirror
+        /// <see cref="CompoundCurve.Boundary"/> until BoundaryOp learns about curves.
+        /// </remarks>
+        public override Geometry Boundary
+        {
+            get
+            {
+                if (IsEmpty || IsClosed)
+                {
+                    return Factory.CreateMultiPoint();
+                }
+                return Factory.CreateMultiPoint(new[] { StartPoint, EndPoint });
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override Envelope ComputeEnvelopeInternal()
+        {
+            if (IsEmpty) return new Envelope();
+            // Conservative: enclose all control points. The true analytical
+            // envelope of an arc may extend beyond control points by up to the
+            // sagitta of the arc; a follow-up will tighten this.
+            var env = new Envelope();
+            for (int i = 0; i < _points.Count; i++)
+                env.ExpandToInclude(_points.GetCoordinate(i));
+            return env;
+        }
+
+        /// <inheritdoc/>
+        public override bool EqualsExact(Geometry other, double tolerance)
+        {
+            if (!IsEquivalentClass(other)) return false;
+            var o = (CircularString)other;
+            if (_points.Count != o._points.Count) return false;
+            var cec = Factory.CoordinateEqualityComparer;
+            for (int i = 0; i < _points.Count; i++)
+            {
+                if (!cec.Equals(_points.GetCoordinate(i), o._points.GetCoordinate(i), tolerance))
+                    return false;
+            }
+            return true;
+        }
+
+        /// <inheritdoc/>
+        public override void Apply(ICoordinateFilter filter)
+        {
+            for (int i = 0; i < _points.Count; i++) filter.Filter(_points.GetCoordinate(i));
+        }
+
+        /// <inheritdoc/>
+        public override void Apply(ICoordinateSequenceFilter filter)
+        {
+            if (_points.Count == 0) return;
+            for (int i = 0; i < _points.Count; i++)
+            {
+                filter.Filter(_points, i);
+                if (filter.Done) break;
+            }
+            if (filter.GeometryChanged) GeometryChanged();
+        }
+
+        /// <inheritdoc/>
+        public override void Apply(IEntireCoordinateSequenceFilter filter)
+        {
+            filter.Filter(_points);
+            if (filter.GeometryChanged) GeometryChanged();
+        }
+
+        /// <inheritdoc/>
+        public override void Apply(IGeometryFilter filter) => filter.Filter(this);
+
+        /// <inheritdoc/>
+        public override void Apply(IGeometryComponentFilter filter) => filter.Filter(this);
+
+        /// <inheritdoc/>
+        protected override Geometry CopyInternal() => new CircularString(_points.Copy(), Factory);
+
+        /// <inheritdoc/>
+        public override void Normalize()
+        {
+            // Two normalization choices for an arc string: (a) keep direction,
+            // (b) flip endpoints when start > end in lex order. Mirror LineString:
+            if (IsEmpty) return;
+            var lex = _points.GetCoordinate(0).CompareTo(_points.GetCoordinate(_points.Count - 1));
+            if (lex > 0) CoordinateSequences.Reverse(_points);
+        }
+
+        /// <inheritdoc/>
+        protected override Geometry ReverseInternal()
+        {
+            var rev = _points.Copy();
+            CoordinateSequences.Reverse(rev);
+            return new CircularString(rev, Factory);
+        }
+
+        /// <inheritdoc/>
+        protected override bool IsEquivalentClass(Geometry other) => other is CircularString;
+
+        /// <summary>
+        /// CompareTo for two CircularStrings uses coordinate-sequence lex order.
+        /// </summary>
+        protected internal override int CompareToSameClass(object o)
+        {
+            var other = (CircularString)o;
+            int n = Math.Min(_points.Count, other._points.Count);
+            for (int i = 0; i < n; i++)
+            {
+                int c = _points.GetCoordinate(i).CompareTo(other._points.GetCoordinate(i));
+                if (c != 0) return c;
+            }
+            return _points.Count.CompareTo(other._points.Count);
+        }
+
+        /// <inheritdoc/>
+        protected internal override int CompareToSameClass(object o, IComparer<CoordinateSequence> comp)
+        {
+            return comp.Compare(_points, ((CircularString)o)._points);
+        }
+
+        /// <inheritdoc/>
+        protected override SortIndexValue SortIndex => SortIndexValue.CircularString;
+
+        /// <summary>
+        /// Returns a chord approximation of this circular string as a
+        /// <see cref="LineString"/> through the control points.
+        /// </summary>
+        /// <remarks>
+        /// Arc-aware densification is deferred; this escape hatch lets algorithms
+        /// fall through to linear geometry without treating control polylines as
+        /// the only model of the type itself.
+        /// </remarks>
+        public LineString Linearize() => Linearize(double.NaN);
+
+        /// <summary>
+        /// Returns a chord approximation of this circular string as a
+        /// <see cref="LineString"/>.
+        /// </summary>
+        /// <param name="arcSegmentLength">
+        /// Reserved for maximum chord length along each arc. Currently unused;
+        /// control-point chords are always returned.
+        /// </param>
+        public LineString Linearize(double arcSegmentLength)
+        {
+            if (IsEmpty)
+            {
+                return Factory.CreateLineString();
+            }
+            return Factory.CreateLineString(_points.Copy());
+        }
+    }
+}

--- a/src/NetTopologySuite/Geometries/Curves/CompoundCurve.cs
+++ b/src/NetTopologySuite/Geometries/Curves/CompoundCurve.cs
@@ -1,0 +1,397 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// AI assistance disclosure:
+//   AI-drafted, human-reviewed and curated. Per the same convention used for the
+//   companion JTS prototype at grootstebozewolf/jts#1, AI-generated portions are
+//   dedicated to CC0-1.0; human curation falls under the NTS BSD-3-Clause grant.
+//
+//   Assisted-by: Claude (Fable 5)
+//
+// Status: PLAYGROUND -- in-tree port of the SQL/MM CompoundCurve prototype from
+// the out-of-tree NetTopologySuite.Curve repository, following the maintainer
+// discussion on the PR ("in-tree is the way to go"). Not for merge into develop
+// without further design discussion -- see the PR description.
+
+using System;
+using System.Collections.Generic;
+
+namespace NetTopologySuite.Geometries.Curves
+{
+    /// <summary>
+    /// A SQL/MM Spatial (ISO/IEC 13249-3) <c>CompoundCurve</c>: a single, contiguous
+    /// curve composed of a sequence of <see cref="Curve"/> components -- in this
+    /// prototype either <see cref="LineString"/>s or <see cref="CircularString"/>s --
+    /// where each component starts at the end point of its predecessor.
+    /// </summary>
+    /// <remarks>
+    /// Nested <c>CompoundCurve</c> components are rejected, keeping the component
+    /// list flat (matching SQL/MM and common implementations).
+    /// <para/>
+    /// This is a prototype.  Like <see cref="CircularString"/>, metric properties
+    /// (<c>Length</c>, envelopes) fall back to the chord-based computations of the
+    /// components rather than analytical arc geometry.
+    /// </remarks>
+    [Serializable]
+    public class CompoundCurve : Curve, ILinearizable<LineString>
+    {
+        /// <summary>The component curves.</summary>
+        private readonly Curve[] _curves;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CompoundCurve"/> class.
+        /// </summary>
+        /// <param name="curves">The component curves, in traversal order</param>
+        /// <param name="factory">The geometry factory</param>
+        /// <exception cref="ArgumentException">
+        /// If a component is <c>null</c>, empty, or a <c>CompoundCurve</c> itself, or
+        /// if a component does not start at the end point of its predecessor.
+        /// </exception>
+        public CompoundCurve(Curve[] curves, GeometryFactory factory) : base(factory)
+        {
+            if (curves == null || curves.Length == 0)
+            {
+                _curves = new Curve[0];
+                return;
+            }
+            for (int i = 0; i < curves.Length; i++)
+            {
+                if (curves[i] == null)
+                {
+                    throw new ArgumentException(
+                        "A CompoundCurve must not contain null components.", nameof(curves));
+                }
+                if (curves[i].IsEmpty)
+                {
+                    throw new ArgumentException(
+                        "A CompoundCurve must not contain empty components.", nameof(curves));
+                }
+                if (curves[i] is CompoundCurve)
+                {
+                    throw new ArgumentException(
+                        "A CompoundCurve must not contain nested CompoundCurve components.",
+                        nameof(curves));
+                }
+                if (i > 0)
+                {
+                    var previousEnd = curves[i - 1].EndPoint.Coordinate;
+                    var currentStart = curves[i].StartPoint.Coordinate;
+                    if (!previousEnd.Equals2D(currentStart))
+                    {
+                        throw new ArgumentException(
+                            "The components of a CompoundCurve must be contiguous: component " + i +
+                            " starts at " + currentStart + " but its predecessor ends at " + previousEnd + ".",
+                            nameof(curves));
+                    }
+                }
+            }
+            // Defensive copy: Normalize reverses and rewrites this array in place.
+            _curves = new Curve[curves.Length];
+            Array.Copy(curves, _curves, curves.Length);
+        }
+
+        /// <summary>
+        /// Gets the component curves of this <c>CompoundCurve</c>.
+        /// </summary>
+        public IReadOnlyList<Curve> Curves => _curves;
+
+        /// <inheritdoc cref="Geometry.IsEmpty"/>
+        public override bool IsEmpty => _curves.Length == 0;
+
+        /// <inheritdoc cref="Geometry.Coordinate"/>
+        public override Coordinate Coordinate => IsEmpty ? null : _curves[0].Coordinate;
+
+        /// <summary>
+        /// The coordinates of the components, concatenated in traversal order with
+        /// the shared join point of adjacent components emitted only once.
+        /// </summary>
+        public override Coordinate[] Coordinates
+        {
+            get
+            {
+                var coordinates = new List<Coordinate>();
+                for (int i = 0; i < _curves.Length; i++)
+                {
+                    var componentCoordinates = _curves[i].Coordinates;
+                    for (int j = i == 0 ? 0 : 1; j < componentCoordinates.Length; j++)
+                    {
+                        coordinates.Add(componentCoordinates[j]);
+                    }
+                }
+                return coordinates.ToArray();
+            }
+        }
+
+        /// <inheritdoc cref="Geometry.NumPoints"/>
+        public override int NumPoints
+        {
+            get
+            {
+                if (IsEmpty) return 0;
+                int numPoints = _curves[0].NumPoints;
+                for (int i = 1; i < _curves.Length; i++)
+                {
+                    numPoints += _curves[i].NumPoints - 1;
+                }
+                return numPoints;
+            }
+        }
+
+        /// <inheritdoc/>
+        public override double[] GetOrdinates(Ordinate ordinate)
+        {
+            if (IsEmpty) return new double[0];
+            var ordinates = new List<double>();
+            for (int i = 0; i < _curves.Length; i++)
+            {
+                double[] componentOrdinates = _curves[i].GetOrdinates(ordinate);
+                for (int j = i == 0 ? 0 : 1; j < componentOrdinates.Length; j++)
+                {
+                    ordinates.Add(componentOrdinates[j]);
+                }
+            }
+            return ordinates.ToArray();
+        }
+
+        /// <inheritdoc cref="Curve.StartPoint"/>
+        public override Point StartPoint =>
+            IsEmpty ? null : _curves[0].StartPoint;
+
+        /// <inheritdoc cref="Curve.EndPoint"/>
+        public override Point EndPoint =>
+            IsEmpty ? null : _curves[_curves.Length - 1].EndPoint;
+
+        /// <inheritdoc cref="Curve.IsClosed"/>
+        public override bool IsClosed
+        {
+            get
+            {
+                if (IsEmpty) return false;
+                return StartPoint.Coordinate.Equals2D(EndPoint.Coordinate);
+            }
+        }
+
+        /// <inheritdoc cref="Geometry.GeometryType"/>
+        public override string GeometryType => "CompoundCurve";
+
+        /// <inheritdoc cref="Geometry.OgcGeometryType"/>
+        public override OgcGeometryType OgcGeometryType => OgcGeometryType.CompoundCurve;
+
+        /// <summary>
+        /// Length approximated by summing component lengths.  For
+        /// <see cref="CircularString"/> components this is the chord-based fallback;
+        /// analytical arc-length computation is tracked in the prototype roadmap.
+        /// </summary>
+        public override double Length
+        {
+            get
+            {
+                double length = 0d;
+                for (int i = 0; i < _curves.Length; i++)
+                {
+                    length += _curves[i].Length;
+                }
+                return length;
+            }
+        }
+
+        /// <summary>
+        /// The boundary of a curve per the Mod-2 rule: empty when the curve is empty
+        /// or closed, otherwise the two end points.
+        /// </summary>
+        public override Geometry Boundary
+        {
+            get
+            {
+                if (IsEmpty || IsClosed)
+                {
+                    return Factory.CreateMultiPoint();
+                }
+                return Factory.CreateMultiPoint(new[] { StartPoint, EndPoint });
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override Envelope ComputeEnvelopeInternal()
+        {
+            var env = new Envelope();
+            for (int i = 0; i < _curves.Length; i++)
+            {
+                env.ExpandToInclude(_curves[i].EnvelopeInternal);
+            }
+            return env;
+        }
+
+        /// <inheritdoc/>
+        public override bool EqualsExact(Geometry other, double tolerance)
+        {
+            if (!IsEquivalentClass(other)) return false;
+            var o = (CompoundCurve)other;
+            if (_curves.Length != o._curves.Length) return false;
+            for (int i = 0; i < _curves.Length; i++)
+            {
+                if (!_curves[i].EqualsExact(o._curves[i], tolerance))
+                    return false;
+            }
+            return true;
+        }
+
+        /// <inheritdoc/>
+        public override void Apply(ICoordinateFilter filter)
+        {
+            for (int i = 0; i < _curves.Length; i++) _curves[i].Apply(filter);
+        }
+
+        /// <inheritdoc/>
+        public override void Apply(ICoordinateSequenceFilter filter)
+        {
+            for (int i = 0; i < _curves.Length; i++)
+            {
+                _curves[i].Apply(filter);
+                if (filter.Done) break;
+            }
+            if (filter.GeometryChanged) GeometryChanged();
+        }
+
+        /// <inheritdoc/>
+        public override void Apply(IEntireCoordinateSequenceFilter filter)
+        {
+            for (int i = 0; i < _curves.Length; i++)
+            {
+                _curves[i].Apply(filter);
+                if (filter.Done) break;
+            }
+            if (filter.GeometryChanged) GeometryChanged();
+        }
+
+        /// <inheritdoc/>
+        public override void Apply(IGeometryFilter filter) => filter.Filter(this);
+
+        /// <inheritdoc/>
+        public override void Apply(IGeometryComponentFilter filter)
+        {
+            filter.Filter(this);
+            for (int i = 0; i < _curves.Length; i++) _curves[i].Apply(filter);
+        }
+
+        /// <inheritdoc/>
+        protected override Geometry CopyInternal()
+        {
+            var curves = new Curve[_curves.Length];
+            for (int i = 0; i < _curves.Length; i++)
+            {
+                curves[i] = (Curve)_curves[i].Copy();
+            }
+            return new CompoundCurve(curves, Factory);
+        }
+
+        /// <inheritdoc/>
+        public override void Normalize()
+        {
+            // Mirror the CircularString choice: flip traversal direction when the
+            // start point is lexicographically greater than the end point.
+            if (IsEmpty) return;
+            if (StartPoint.Coordinate.CompareTo(EndPoint.Coordinate) > 0)
+            {
+                Array.Reverse(_curves);
+                for (int i = 0; i < _curves.Length; i++)
+                {
+                    _curves[i] = (Curve)_curves[i].Reverse();
+                }
+                GeometryChanged();
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override Geometry ReverseInternal()
+        {
+            var curves = new Curve[_curves.Length];
+            for (int i = 0; i < _curves.Length; i++)
+            {
+                curves[i] = (Curve)_curves[_curves.Length - 1 - i].Reverse();
+            }
+            return new CompoundCurve(curves, Factory);
+        }
+
+        /// <inheritdoc/>
+        protected override bool IsEquivalentClass(Geometry other) => other is CompoundCurve;
+
+        /// <summary>
+        /// CompareTo for two CompoundCurves uses lex order of the concatenated
+        /// coordinates (type-blind across component kinds).
+        /// </summary>
+        protected internal override int CompareToSameClass(object o)
+        {
+            var other = (CompoundCurve)o;
+            var a = Coordinates;
+            var b = other.Coordinates;
+            int n = Math.Min(a.Length, b.Length);
+            for (int i = 0; i < n; i++)
+            {
+                int c = a[i].CompareTo(b[i]);
+                if (c != 0) return c;
+            }
+            return a.Length.CompareTo(b.Length);
+        }
+
+        /// <inheritdoc/>
+        protected internal override int CompareToSameClass(object o, IComparer<CoordinateSequence> comp)
+        {
+            var other = (CompoundCurve)o;
+            var factory = Factory.CoordinateSequenceFactory;
+            return comp.Compare(factory.Create(Coordinates), factory.Create(other.Coordinates));
+        }
+
+        /// <inheritdoc/>
+        protected override SortIndexValue SortIndex => SortIndexValue.CompoundCurve;
+
+        /// <summary>
+        /// Returns a chord approximation of this compound curve as a single
+        /// <see cref="LineString"/>, concatenating linearized components and
+        /// collapsing shared join points.
+        /// </summary>
+        public LineString Linearize() => Linearize(double.NaN);
+
+        /// <summary>
+        /// Returns a chord approximation of this compound curve as a single
+        /// <see cref="LineString"/>.
+        /// </summary>
+        /// <param name="arcSegmentLength">
+        /// Passed through to <see cref="CircularString"/> components when they
+        /// support densification; currently reserved (control chords).
+        /// </param>
+        public LineString Linearize(double arcSegmentLength)
+        {
+            if (IsEmpty)
+            {
+                return Factory.CreateLineString();
+            }
+
+            var coordinates = new List<Coordinate>();
+            for (int i = 0; i < _curves.Length; i++)
+            {
+                LineString componentLine = LinearizeComponent(_curves[i], arcSegmentLength);
+                var componentCoordinates = componentLine.Coordinates;
+                for (int j = i == 0 ? 0 : 1; j < componentCoordinates.Length; j++)
+                {
+                    coordinates.Add(componentCoordinates[j]);
+                }
+            }
+            return Factory.CreateLineString(coordinates.ToArray());
+        }
+
+        private static LineString LinearizeComponent(Curve component, double arcSegmentLength)
+        {
+            switch (component)
+            {
+                case CircularString circularString:
+                    return circularString.Linearize(arcSegmentLength);
+                case LineString lineString:
+                    return lineString;
+                default:
+                    // Defensive: constructor rejects nested CompoundCurves; other
+                    // Curve subtypes should linearize via control coordinates.
+                    return component.Factory.CreateLineString(component.Coordinates);
+            }
+        }
+    }
+}

--- a/src/NetTopologySuite/Geometries/Curves/CurvePolygon.cs
+++ b/src/NetTopologySuite/Geometries/Curves/CurvePolygon.cs
@@ -1,0 +1,446 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// AI assistance disclosure:
+//   AI-drafted, human-reviewed and curated. Per the same convention used for the
+//   companion JTS prototype at grootstebozewolf/jts#1, AI-generated portions are
+//   dedicated to CC0-1.0; human curation falls under the NTS BSD-3-Clause grant.
+//
+//   Assisted-by: Claude (Fable 5)
+//
+// Status: PLAYGROUND -- in-tree port of the SQL/MM CurvePolygon prototype from
+// the out-of-tree NetTopologySuite.Curve repository, following the maintainer
+// discussion on the PR ("in-tree is the way to go"). This carries the F-CP
+// structural contract of the SFA Curve Awareness epic (locationtech/jts#1195,
+// Phase 1): rings are exposed as Curve, never collapsed to LinearRing.
+// Not for merge into develop without further design discussion -- see the PR
+// description.
+
+using System;
+using System.Collections.Generic;
+
+namespace NetTopologySuite.Geometries.Curves
+{
+    /// <summary>
+    /// A SQL/MM Spatial (ISO/IEC 13249-3) <c>CurvePolygon</c>: a planar surface like
+    /// <see cref="Polygon"/>, but whose exterior and interior rings are
+    /// <see cref="Curve"/>s -- <see cref="LinearRing"/>s, closed
+    /// <see cref="CircularString"/>s or closed <see cref="CompoundCurve"/>s.
+    /// </summary>
+    /// <remarks>
+    /// Because <c>CurvePolygon</c> extends <c>Surface&lt;Curve&gt;</c> rather than
+    /// <c>Polygon</c>, the ring accessors are typed <see cref="Curve"/> and never
+    /// collapse a curved ring to a flat <see cref="LinearRing"/> (the F-CP
+    /// structural contract).
+    /// <para/>
+    /// This is a prototype.  <c>Area</c> and <c>Length</c> fall back to chord-based
+    /// computations that treat the control points of curved rings as polylines;
+    /// analytical arc geometry and linearization are tracked in the prototype
+    /// roadmap.
+    /// </remarks>
+    [Serializable]
+    public class CurvePolygon : Surface<Curve>, ILinearizable<Polygon>
+    {
+        /// <summary>The exterior ring.</summary>
+        private readonly Curve _shell;
+
+        /// <summary>The interior rings.</summary>
+        private readonly Curve[] _holes;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CurvePolygon"/> class with no
+        /// interior rings.
+        /// </summary>
+        /// <param name="shell">The exterior ring, a closed <c>Curve</c> (or null for an empty polygon)</param>
+        /// <param name="factory">The geometry factory</param>
+        public CurvePolygon(Curve shell, GeometryFactory factory)
+            : this(shell, null, factory)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CurvePolygon"/> class.
+        /// </summary>
+        /// <param name="shell">The exterior ring, a closed <c>Curve</c> (or null for an empty polygon)</param>
+        /// <param name="holes">The interior rings, closed <c>Curve</c>s</param>
+        /// <param name="factory">The geometry factory</param>
+        /// <exception cref="ArgumentException">
+        /// If a ring is not closed, a hole is <c>null</c>, or the shell is empty while
+        /// holes are not.
+        /// </exception>
+        public CurvePolygon(Curve shell, Curve[] holes, GeometryFactory factory) : base(factory)
+        {
+            if (shell == null)
+            {
+                shell = new CircularString(factory.CoordinateSequenceFactory.Create(0, Ordinates.XY), factory);
+            }
+            if (holes == null || holes.Length == 0)
+            {
+                holes = new Curve[0];
+            }
+            else
+            {
+                // Defensive copy so callers cannot mutate the ring list after construction.
+                var holesCopy = new Curve[holes.Length];
+                Array.Copy(holes, holesCopy, holes.Length);
+                holes = holesCopy;
+            }
+            foreach (var hole in holes)
+            {
+                if (hole == null)
+                {
+                    throw new ArgumentException(
+                        "A CurvePolygon must not contain null holes.", nameof(holes));
+                }
+            }
+            if (shell.IsEmpty && HasNonEmptyElements(holes))
+            {
+                throw new ArgumentException("shell is empty but holes are not", nameof(holes));
+            }
+            if (!shell.IsEmpty && !shell.IsClosed)
+            {
+                throw new ArgumentException(
+                    "The shell of a CurvePolygon must be closed.", nameof(shell));
+            }
+            foreach (var hole in holes)
+            {
+                if (!hole.IsEmpty && !hole.IsClosed)
+                {
+                    throw new ArgumentException(
+                        "The holes of a CurvePolygon must be closed.", nameof(holes));
+                }
+            }
+            _shell = shell;
+            _holes = holes;
+        }
+
+        private static bool HasNonEmptyElements(Curve[] curves)
+        {
+            foreach (var curve in curves)
+            {
+                if (!curve.IsEmpty) return true;
+            }
+            return false;
+        }
+
+        /// <inheritdoc cref="Surface{T}.ExteriorRing"/>
+        public override Curve ExteriorRing => _shell;
+
+        /// <inheritdoc cref="Surface{T}.NumInteriorRings"/>
+        public override int NumInteriorRings => _holes.Length;
+
+        /// <inheritdoc cref="Surface{T}.GetInteriorRingN"/>
+        public override Curve GetInteriorRingN(int index) => _holes[index];
+
+        /// <inheritdoc cref="Geometry.GeometryType"/>
+        public override string GeometryType => "CurvePolygon";
+
+        /// <inheritdoc cref="Geometry.OgcGeometryType"/>
+        public override OgcGeometryType OgcGeometryType => OgcGeometryType.CurvePolygon;
+
+        /// <inheritdoc cref="Geometry.IsEmpty"/>
+        public override bool IsEmpty => _shell.IsEmpty;
+
+        /// <inheritdoc cref="Geometry.Coordinate"/>
+        public override Coordinate Coordinate => _shell.Coordinate;
+
+        /// <inheritdoc cref="Geometry.Coordinates"/>
+        public override Coordinate[] Coordinates
+        {
+            get
+            {
+                if (IsEmpty) return new Coordinate[0];
+                var coordinates = new List<Coordinate>(_shell.Coordinates);
+                foreach (var hole in _holes)
+                {
+                    coordinates.AddRange(hole.Coordinates);
+                }
+                return coordinates.ToArray();
+            }
+        }
+
+        /// <inheritdoc cref="Geometry.NumPoints"/>
+        public override int NumPoints
+        {
+            get
+            {
+                int numPoints = _shell.NumPoints;
+                foreach (var hole in _holes)
+                {
+                    numPoints += hole.NumPoints;
+                }
+                return numPoints;
+            }
+        }
+
+        /// <inheritdoc/>
+        public override double[] GetOrdinates(Ordinate ordinate)
+        {
+            if (IsEmpty) return new double[0];
+            var ordinates = new List<double>(_shell.GetOrdinates(ordinate));
+            foreach (var hole in _holes)
+            {
+                ordinates.AddRange(hole.GetOrdinates(ordinate));
+            }
+            return ordinates.ToArray();
+        }
+
+        /// <summary>
+        /// Area approximated by treating the control points of the rings as polyline
+        /// rings (chord-based, consistent with <see cref="CircularString"/>'s
+        /// chord-based <c>Length</c>).  For curved rings the true area differs by the
+        /// circular segments; analytical arc area is tracked in the prototype roadmap.
+        /// </summary>
+        public override double Area
+        {
+            get
+            {
+                if (IsEmpty) return 0d;
+                double area = Algorithm.Area.OfRing(_shell.Coordinates);
+                foreach (var hole in _holes)
+                {
+                    area -= Algorithm.Area.OfRing(hole.Coordinates);
+                }
+                return area;
+            }
+        }
+
+        /// <summary>
+        /// Perimeter approximated by summing ring lengths (chord-based for curved
+        /// rings).
+        /// </summary>
+        public override double Length
+        {
+            get
+            {
+                double length = _shell.Length;
+                foreach (var hole in _holes)
+                {
+                    length += hole.Length;
+                }
+                return length;
+            }
+        }
+
+        /// <summary>
+        /// The rings of this surface.  Returned as a <see cref="GeometryCollection"/>
+        /// of <see cref="Curve"/>s for now -- a dedicated <c>MultiCurve</c> type is
+        /// part of the prototype roadmap.
+        /// </summary>
+        public override Geometry Boundary
+        {
+            get
+            {
+                if (IsEmpty)
+                {
+                    return Factory.CreateGeometryCollection();
+                }
+                var rings = new Geometry[1 + _holes.Length];
+                rings[0] = _shell;
+                for (int i = 0; i < _holes.Length; i++)
+                {
+                    rings[i + 1] = _holes[i];
+                }
+                return Factory.CreateGeometryCollection(rings);
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override Envelope ComputeEnvelopeInternal() => _shell.EnvelopeInternal;
+
+        /// <inheritdoc/>
+        public override bool EqualsExact(Geometry other, double tolerance)
+        {
+            if (!IsEquivalentClass(other)) return false;
+            var o = (CurvePolygon)other;
+            if (!_shell.EqualsExact(o._shell, tolerance)) return false;
+            if (_holes.Length != o._holes.Length) return false;
+            for (int i = 0; i < _holes.Length; i++)
+            {
+                if (!_holes[i].EqualsExact(o._holes[i], tolerance))
+                    return false;
+            }
+            return true;
+        }
+
+        /// <inheritdoc/>
+        public override void Apply(ICoordinateFilter filter)
+        {
+            _shell.Apply(filter);
+            foreach (var hole in _holes) hole.Apply(filter);
+        }
+
+        /// <inheritdoc/>
+        public override void Apply(ICoordinateSequenceFilter filter)
+        {
+            _shell.Apply(filter);
+            if (!filter.Done)
+            {
+                foreach (var hole in _holes)
+                {
+                    hole.Apply(filter);
+                    if (filter.Done) break;
+                }
+            }
+            if (filter.GeometryChanged) GeometryChanged();
+        }
+
+        /// <inheritdoc/>
+        public override void Apply(IEntireCoordinateSequenceFilter filter)
+        {
+            _shell.Apply(filter);
+            if (!filter.Done)
+            {
+                foreach (var hole in _holes)
+                {
+                    hole.Apply(filter);
+                    if (filter.Done) break;
+                }
+            }
+            if (filter.GeometryChanged) GeometryChanged();
+        }
+
+        /// <inheritdoc/>
+        public override void Apply(IGeometryFilter filter) => filter.Filter(this);
+
+        /// <inheritdoc/>
+        public override void Apply(IGeometryComponentFilter filter)
+        {
+            filter.Filter(this);
+            _shell.Apply(filter);
+            foreach (var hole in _holes) hole.Apply(filter);
+        }
+
+        /// <inheritdoc/>
+        protected override Geometry CopyInternal()
+        {
+            var holes = new Curve[_holes.Length];
+            for (int i = 0; i < _holes.Length; i++)
+            {
+                holes[i] = (Curve)_holes[i].Copy();
+            }
+            return new CurvePolygon((Curve)_shell.Copy(), holes, Factory);
+        }
+
+        /// <summary>
+        /// Normalization of ring orientation and hole ordering requires orientation
+        /// of curved rings, which is part of the prototype roadmap.  This prototype
+        /// implementation does nothing.
+        /// </summary>
+        public override void Normalize()
+        {
+        }
+
+        /// <inheritdoc/>
+        protected override Geometry ReverseInternal()
+        {
+            var holes = new Curve[_holes.Length];
+            for (int i = 0; i < _holes.Length; i++)
+            {
+                holes[i] = (Curve)_holes[i].Reverse();
+            }
+            return new CurvePolygon((Curve)_shell.Reverse(), holes, Factory);
+        }
+
+        /// <inheritdoc/>
+        protected override bool IsEquivalentClass(Geometry other) => other is CurvePolygon;
+
+        /// <summary>
+        /// CompareTo for two CurvePolygons uses lex order of the shell coordinates,
+        /// then the hole count, then lex order of the hole coordinates (type-blind
+        /// across ring kinds).
+        /// </summary>
+        protected internal override int CompareToSameClass(object o)
+        {
+            var other = (CurvePolygon)o;
+            int c = CompareCoordinates(_shell.Coordinates, other._shell.Coordinates);
+            if (c != 0) return c;
+            c = _holes.Length.CompareTo(other._holes.Length);
+            if (c != 0) return c;
+            for (int i = 0; i < _holes.Length; i++)
+            {
+                c = CompareCoordinates(_holes[i].Coordinates, other._holes[i].Coordinates);
+                if (c != 0) return c;
+            }
+            return 0;
+        }
+
+        /// <inheritdoc/>
+        protected internal override int CompareToSameClass(object o, IComparer<CoordinateSequence> comp)
+        {
+            var other = (CurvePolygon)o;
+            var factory = Factory.CoordinateSequenceFactory;
+            return comp.Compare(factory.Create(Coordinates), factory.Create(other.Coordinates));
+        }
+
+        private static int CompareCoordinates(Coordinate[] a, Coordinate[] b)
+        {
+            int n = Math.Min(a.Length, b.Length);
+            for (int i = 0; i < n; i++)
+            {
+                int c = a[i].CompareTo(b[i]);
+                if (c != 0) return c;
+            }
+            return a.Length.CompareTo(b.Length);
+        }
+
+        /// <inheritdoc/>
+        protected override SortIndexValue SortIndex => SortIndexValue.CurvePolygon;
+
+        /// <summary>
+        /// Returns a chord approximation of this curve polygon as a linear
+        /// <see cref="Polygon"/> whose rings are linearized control polylines.
+        /// </summary>
+        public Polygon Linearize() => Linearize(double.NaN);
+
+        /// <summary>
+        /// Returns a chord approximation of this curve polygon as a linear
+        /// <see cref="Polygon"/>.
+        /// </summary>
+        /// <param name="arcSegmentLength">
+        /// Passed through to curved rings when they support densification;
+        /// currently reserved (control chords).
+        /// </param>
+        public Polygon Linearize(double arcSegmentLength)
+        {
+            if (IsEmpty)
+            {
+                return Factory.CreatePolygon();
+            }
+
+            var shell = LinearizeRing(_shell, arcSegmentLength);
+            LinearRing[] holes = null;
+            if (_holes.Length > 0)
+            {
+                holes = new LinearRing[_holes.Length];
+                for (int i = 0; i < _holes.Length; i++)
+                {
+                    holes[i] = LinearizeRing(_holes[i], arcSegmentLength);
+                }
+            }
+            return Factory.CreatePolygon(shell, holes);
+        }
+
+        private LinearRing LinearizeRing(Curve ring, double arcSegmentLength)
+        {
+            LineString line;
+            switch (ring)
+            {
+                case CircularString circularString:
+                    line = circularString.Linearize(arcSegmentLength);
+                    break;
+                case CompoundCurve compoundCurve:
+                    line = compoundCurve.Linearize(arcSegmentLength);
+                    break;
+                case LinearRing linearRing:
+                    return linearRing;
+                case LineString lineString:
+                    line = lineString;
+                    break;
+                default:
+                    line = Factory.CreateLineString(ring.Coordinates);
+                    break;
+            }
+            return Factory.CreateLinearRing(line.CoordinateSequence);
+        }
+    }
+}

--- a/src/NetTopologySuite/Geometries/Curves/Tin.cs
+++ b/src/NetTopologySuite/Geometries/Curves/Tin.cs
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// AI assistance disclosure: AI-drafted, human-reviewed.
+//   Assisted-by: Claude (Opus-4.7)
+//
+// Status: PLAYGROUND -- prototype of OGC SFA-CA Triangulated Irregular
+// Network (TIN), modeled as a GeometryCollection of Triangle (also defined in
+// this Curves namespace).  Not for merge.
+
+using System;
+
+namespace NetTopologySuite.Geometries.Curves
+{
+    /// <summary>
+    /// An OGC SFA-CA Triangulated Irregular Network: a homogeneous collection of
+    /// <see cref="Triangle"/>s.  Conceptually a piecewise-linear surface, but
+    /// represented here as a <see cref="GeometryCollection"/> for tooling
+    /// compatibility on the prototype branch.
+    /// </summary>
+    /// <remarks>
+    /// All elements are required to be <see cref="Triangle"/> instances; the
+    /// constructor enforces this.  Adjacency, shared-edge consistency, and
+    /// orientation invariants are not currently checked -- those are downstream
+    /// validity properties that should accompany an eventual
+    /// <c>IsValid</c>-style predicate.
+    /// </remarks>
+    [Serializable]
+    public class Tin : GeometryCollection
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Tin"/> class.
+        /// </summary>
+        /// <param name="triangles">The constituent triangles (may be empty or null)</param>
+        /// <param name="factory">The geometry factory</param>
+        public Tin(Triangle[] triangles, GeometryFactory factory)
+            : base(triangles ?? new Triangle[0], factory)
+        {
+            // The base ctor accepts Geometry[]; the array contravariance is fine
+            // here because Triangle inherits from Geometry. The element-type
+            // constraint is encoded in the (Triangle[]) parameter signature, so
+            // downstream code can't slip a non-Triangle in through this entry
+            // point. The Geometry[] form on the base class is still reachable
+            // via the inherited APIs; an IsValid-style invariant check would
+            // catch that case.
+        }
+
+        /// <inheritdoc cref="Geometry.GeometryType"/>
+        public override string GeometryType => "TIN";
+
+        /// <inheritdoc cref="Geometry.OgcGeometryType"/>
+        public override OgcGeometryType OgcGeometryType => OgcGeometryType.TIN;
+
+        /// <summary>The dimension of a TIN is that of a surface (2).</summary>
+        public override Dimension Dimension => Dimension.Surface;
+
+        /// <summary>The boundary of a TIN is curvilinear (the perimeter of the union).</summary>
+        public override Dimension BoundaryDimension => Dimension.Curve;
+
+        /// <summary>
+        /// Gets the triangle at the given index.
+        /// </summary>
+        public Triangle GetTriangleN(int index) => (Triangle)GetGeometryN(index);
+
+        /// <inheritdoc/>
+        protected override Geometry CopyInternal()
+        {
+            var copies = new Triangle[NumGeometries];
+            for (int i = 0; i < NumGeometries; i++)
+            {
+                copies[i] = (Triangle)GetGeometryN(i).Copy();
+            }
+            return new Tin(copies, Factory);
+        }
+
+        /// <inheritdoc/>
+        protected override bool IsEquivalentClass(Geometry other) => other is Tin;
+
+        /// <summary>
+        /// The total area of the TIN, computed as the sum of triangle areas.
+        /// Adjacent triangles that overlap will double-count; the prototype
+        /// assumes a well-formed TIN.
+        /// </summary>
+        public override double Area
+        {
+            get
+            {
+                double total = 0.0;
+                for (int i = 0; i < NumGeometries; i++)
+                {
+                    total += ((Triangle)GetGeometryN(i)).Area;
+                }
+                return total;
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override SortIndexValue SortIndex => SortIndexValue.Tin;
+    }
+}

--- a/src/NetTopologySuite/Geometries/Curves/Triangle.cs
+++ b/src/NetTopologySuite/Geometries/Curves/Triangle.cs
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// AI assistance disclosure: AI-drafted, human-reviewed.
+//   Assisted-by: Claude (Opus-4.7)
+//
+// Status: PLAYGROUND -- prototype of OGC SFA Triangle on the enhancement/curved
+// foundational Surface<T> abstraction.  Not for merge.
+
+using System;
+using System.Collections.Generic;
+
+namespace NetTopologySuite.Geometries.Curves
+{
+    /// <summary>
+    /// An OGC SFA <c>Triangle</c>: a <see cref="Surface{T}"/> whose exterior ring has
+    /// exactly four coordinates (three distinct vertices plus a closing repeat) and
+    /// no interior rings.
+    /// </summary>
+    /// <remarks>
+    /// This is a sibling of the existing <see cref="Geometries.Triangle"/> utility
+    /// class -- they live in different namespaces.  The utility class provides
+    /// <c>InCentre</c> / <c>IsAcute</c> / <c>PerpendicularBisector</c> on raw
+    /// <see cref="Coordinate"/>s without participating in the geometry hierarchy;
+    /// this class is a full <see cref="Geometry"/> that takes part in WKT, WKB,
+    /// envelopes, predicates, etc.
+    /// </remarks>
+    [Serializable]
+    public class Triangle : Surface<LinearRing>
+    {
+        private readonly LinearRing _shell;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Triangle"/> class from a
+        /// closed 4-coordinate shell.
+        /// </summary>
+        /// <param name="shell">A linear ring with exactly four coordinates (or empty)</param>
+        /// <param name="factory">The geometry factory</param>
+        /// <exception cref="ArgumentException">
+        /// If the shell is non-empty and does not have exactly four coordinates.
+        /// </exception>
+        public Triangle(LinearRing shell, GeometryFactory factory) : base(factory)
+        {
+            shell = shell ?? factory.CreateLinearRing((CoordinateSequence)null);
+            if (!shell.IsEmpty && shell.NumPoints != 4)
+            {
+                throw new ArgumentException(
+                    "A Triangle must have a 4-coordinate shell (3 distinct vertices " +
+                    "plus a closing repeat), got " + shell.NumPoints + " points.",
+                    nameof(shell));
+            }
+            _shell = shell;
+        }
+
+        /// <inheritdoc cref="Geometry.GeometryType"/>
+        public override string GeometryType => "Triangle";
+
+        /// <inheritdoc cref="Geometry.OgcGeometryType"/>
+        public override OgcGeometryType OgcGeometryType => OgcGeometryType.Triangle;
+
+        /// <inheritdoc cref="Geometry.IsEmpty"/>
+        public override bool IsEmpty => _shell.IsEmpty;
+
+        /// <inheritdoc cref="Geometry.NumPoints"/>
+        public override int NumPoints => _shell.NumPoints;
+
+        /// <inheritdoc cref="Geometry.Coordinate"/>
+        public override Coordinate Coordinate => _shell.Coordinate;
+
+        /// <inheritdoc cref="Geometry.Coordinates"/>
+        public override Coordinate[] Coordinates => _shell.Coordinates;
+
+        /// <inheritdoc/>
+        public override double[] GetOrdinates(Ordinate ordinate) => _shell.GetOrdinates(ordinate);
+
+        /// <inheritdoc cref="Surface{T}.ExteriorRing"/>
+        public override LinearRing ExteriorRing => _shell;
+
+        /// <inheritdoc cref="Surface{T}.NumInteriorRings"/>
+        public override int NumInteriorRings => 0;
+
+        /// <inheritdoc cref="Surface{T}.GetInteriorRingN"/>
+        public override LinearRing GetInteriorRingN(int index)
+        {
+            throw new ArgumentOutOfRangeException(nameof(index),
+                "A Triangle has no interior rings.");
+        }
+
+        /// <summary>
+        /// Signed twice-area of the triangle (positive for CCW vertices, negative
+        /// for CW, zero for a degenerate triangle).
+        /// </summary>
+        public double SignedDoubleArea
+        {
+            get
+            {
+                if (IsEmpty) return 0.0;
+                var c = _shell.Coordinates;
+                return (c[1].X - c[0].X) * (c[2].Y - c[0].Y)
+                     - (c[2].X - c[0].X) * (c[1].Y - c[0].Y);
+            }
+        }
+
+        /// <inheritdoc cref="Geometry.Area"/>
+        public override double Area => Math.Abs(SignedDoubleArea) / 2.0;
+
+        /// <inheritdoc cref="Geometry.Length"/>
+        public override double Length => _shell.Length;
+
+        /// <inheritdoc cref="Geometry.Boundary"/>
+        public override Geometry Boundary => IsEmpty
+            ? (Geometry)Factory.CreateMultiLineString()
+            : Factory.CreateLineString(_shell.CoordinateSequence.Copy());
+
+        /// <inheritdoc/>
+        protected override Envelope ComputeEnvelopeInternal() => _shell.EnvelopeInternal;
+
+        /// <inheritdoc/>
+        public override bool EqualsExact(Geometry other, double tolerance)
+        {
+            if (!IsEquivalentClass(other)) return false;
+            var o = (Triangle)other;
+            return _shell.EqualsExact(o._shell, tolerance);
+        }
+
+        /// <inheritdoc/>
+        public override void Apply(ICoordinateFilter filter) => _shell.Apply(filter);
+
+        /// <inheritdoc/>
+        public override void Apply(ICoordinateSequenceFilter filter)
+        {
+            _shell.Apply(filter);
+            if (filter.GeometryChanged) GeometryChanged();
+        }
+
+        /// <inheritdoc/>
+        public override void Apply(IEntireCoordinateSequenceFilter filter)
+        {
+            _shell.Apply(filter);
+            if (filter.GeometryChanged) GeometryChanged();
+        }
+
+        /// <inheritdoc/>
+        public override void Apply(IGeometryFilter filter) => filter.Filter(this);
+
+        /// <inheritdoc/>
+        public override void Apply(IGeometryComponentFilter filter)
+        {
+            filter.Filter(this);
+            _shell.Apply(filter);
+        }
+
+        /// <inheritdoc/>
+        protected override Geometry CopyInternal() => new Triangle((LinearRing)_shell.Copy(), Factory);
+
+        /// <inheritdoc/>
+        public override void Normalize() => _shell.Normalize();
+
+        /// <inheritdoc/>
+        protected override Geometry ReverseInternal() =>
+            new Triangle((LinearRing)_shell.Reverse(), Factory);
+
+        /// <inheritdoc/>
+        protected override bool IsEquivalentClass(Geometry other) => other is Triangle;
+
+        /// <inheritdoc/>
+        protected internal override int CompareToSameClass(object o)
+        {
+            return _shell.CompareTo(((Triangle)o)._shell);
+        }
+
+        /// <inheritdoc/>
+        protected internal override int CompareToSameClass(object o, IComparer<CoordinateSequence> comp)
+        {
+            return comp.Compare(_shell.CoordinateSequence, ((Triangle)o)._shell.CoordinateSequence);
+        }
+
+        /// <inheritdoc/>
+        protected override SortIndexValue SortIndex => SortIndexValue.Triangle;
+    }
+}

--- a/src/NetTopologySuite/Geometries/Geometry.cs
+++ b/src/NetTopologySuite/Geometries/Geometry.cs
@@ -141,7 +141,17 @@ namespace NetTopologySuite.Geometries
             /// <summary>Sort hierarchy value of a <see cref="MultiPolygon"/></summary>
             MultiPolygon = 6,
             /// <summary>Sort hierarchy value of a <see cref="GeometryCollection"/></summary>
-            GeometryCollection = 7
+            GeometryCollection = 7,
+            /// <summary>Sort hierarchy value of a <see cref="Curves.CircularString"/></summary>
+            CircularString = 8,
+            /// <summary>Sort hierarchy value of a <see cref="Curves.CompoundCurve"/></summary>
+            CompoundCurve = 9,
+            /// <summary>Sort hierarchy value of a <see cref="Curves.CurvePolygon"/></summary>
+            CurvePolygon = 10,
+            /// <summary>Sort hierarchy value of a <see cref="Curves.Triangle"/></summary>
+            Triangle = 11,
+            /// <summary>Sort hierarchy value of a <see cref="Curves.Tin"/></summary>
+            Tin = 12
         }
 
         /// <summary>

--- a/src/NetTopologySuite/Geometries/GeometryCollection.cs
+++ b/src/NetTopologySuite/Geometries/GeometryCollection.cs
@@ -20,6 +20,12 @@ namespace NetTopologySuite.Geometries
         /// </summary>
         private Geometry[] _geometries;
 
+        private bool _dimCacheComputed;
+        private Dimension _cachedDimension;
+        private bool _hasP;
+        private bool _hasL;
+        private bool _hasA;
+
         /// <summary>
         ///
         /// </summary>
@@ -136,27 +142,46 @@ namespace NetTopologySuite.Geometries
             }
         }
 
+        private void InitDimCache()
+        {
+            if (_dimCacheComputed) return;
+            var dim = Dimension.False;
+            bool hasP = false, hasL = false, hasA = false;
+            foreach (var elem in new GeometryCollectionEnumerator(this))
+            {
+                if (elem is GeometryCollection) continue;
+                if (elem is Point) { hasP = true; if (dim < Dimension.Point) dim = Dimension.Point; }
+                else if (elem is LineString) { hasL = true; if (dim < Dimension.Curve) dim = Dimension.Curve; }
+                else if (elem is Polygon) { hasA = true; if (dim < Dimension.Surface) dim = Dimension.Surface; }
+            }
+            _hasP = hasP;
+            _hasL = hasL;
+            _hasA = hasA;
+            _cachedDimension = dim;
+            _dimCacheComputed = true;
+        }
+
         /// <inheritdoc cref="Geometry.Dimension"/>
         public override Dimension Dimension
         {
             get
             {
-                var dimension = Dimension.False;
-                for (int i = 0; i < _geometries.Length; i++)
-                    dimension = (Dimension) Math.Max((int)dimension, (int)_geometries[i].Dimension);
-                return dimension;
+                InitDimCache();
+                return _cachedDimension;
             }
         }
 
         /// <inheritdoc cref="Geometry.HasDimension(Dimension)"/>
         public override bool HasDimension(Dimension dim)
         {
-            for (int i = 0; i < _geometries.Length; i++)
+            InitDimCache();
+            switch (dim)
             {
-                if (_geometries[i].HasDimension(dim))
-                    return true;
+                case Dimension.Surface: return _hasA;
+                case Dimension.Curve: return _hasL;
+                case Dimension.Point: return _hasP;
+                default: return false;
             }
-            return false;
         }
 
         /// <inheritdoc cref="Geometry.BoundaryDimension"/>

--- a/src/NetTopologySuite/Geometries/ILinearizable.cs
+++ b/src/NetTopologySuite/Geometries/ILinearizable.cs
@@ -1,0 +1,23 @@
+﻿namespace NetTopologySuite.Geometries
+{
+    /// <summary>
+    /// Interface for geometries that can be either approximated to linear geometries themselves or their components
+    /// </summary>
+    /// <typeparam name="T">The type of the linearized geometry</typeparam>
+    public interface ILinearizable<out T> where T:Geometry
+    {
+        /// <summary>
+        /// Approximates this geometry through linearization of non-linear components.
+        /// </summary>
+        /// <returns>A linearized approximation of this geometry.</returns>
+        T Linearize();
+
+        /// <summary>
+        /// Approximates this geometry through linearization of non-linear components.
+        /// </summary>
+        /// <param name="arcSegmentLength">The maximum length of </param>
+        /// <returns>A linearized approximation of this geometry.</returns>
+        T Linearize(double arcSegmentLength);
+
+    }
+}

--- a/src/NetTopologySuite/Geometries/LineString.cs
+++ b/src/NetTopologySuite/Geometries/LineString.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using NetTopologySuite.Operation;
 using NetTopologySuite.Utilities;
@@ -22,7 +22,7 @@ namespace NetTopologySuite.Geometries
     /// </para>
     /// </remarks>
     [Serializable]
-    public class LineString : Geometry, ILineal
+    public class LineString : Curve
     {
         /// <summary>
         /// The minimum number of vertices allowed in a valid non-empty linestring.
@@ -152,26 +152,6 @@ namespace NetTopologySuite.Geometries
         /// <summary>
         ///
         /// </summary>
-        public override Dimension Dimension => Dimension.Curve;
-
-        /// <summary>
-        ///
-        /// </summary>
-        public override Dimension BoundaryDimension
-        {
-            get
-            {
-                if (IsClosed)
-                {
-                    return Dimension.False;
-                }
-                return Dimension.Point;
-            }
-        }
-
-        /// <summary>
-        ///
-        /// </summary>
         public override bool IsEmpty => _points.Count == 0;
 
         /// <summary>
@@ -192,7 +172,7 @@ namespace NetTopologySuite.Geometries
         /// <summary>
         /// Gets a value indicating the start point of this <c>LINESTRING</c>
         /// </summary>
-        public Point StartPoint
+        public sealed override Point StartPoint
         {
             get
             {
@@ -205,7 +185,7 @@ namespace NetTopologySuite.Geometries
         /// <summary>
         /// Gets a value indicating the end point of this <c>LINESTRING</c>
         /// </summary>
-        public Point EndPoint
+        public sealed override Point EndPoint
         {
             get
             {
@@ -229,12 +209,7 @@ namespace NetTopologySuite.Geometries
         /// <c>true</c> if this LineString is non-empty and closed;
         /// otherwise, <c>false</c>.
         /// </returns>
-        public virtual bool IsClosed => _points.IsClosed;
-
-        /// <summary>
-        /// Gets a value indicating if this <c>LINESTRING</c> forms a ring.
-        /// </summary>
-        public bool IsRing => IsClosed && IsSimple;
+        public override bool IsClosed => _points.IsClosed;
 
         /// <summary>
         /// Returns the name of this object's interface.

--- a/src/NetTopologySuite/Geometries/OgcGeometryType.cs
+++ b/src/NetTopologySuite/Geometries/OgcGeometryType.cs
@@ -87,7 +87,11 @@ namespace NetTopologySuite.Geometries
         TIN = 16,
 // ReSharper restore InconsistentNaming
 
-        
+        /// <summary>
+        /// Triangle (SFA-CA). A polygon with exactly three distinct vertices.
+        /// </summary>
+        Triangle = 17,
+
 
 
         /*

--- a/src/NetTopologySuite/Geometries/Polygon.cs
+++ b/src/NetTopologySuite/Geometries/Polygon.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using NetTopologySuite.Algorithm;
@@ -30,7 +30,7 @@ namespace NetTopologySuite.Geometries
     /// </list>
     /// </summary>
     [Serializable]
-    public class Polygon : Geometry, IPolygonal
+    public class Polygon : Surface<LineString>
     {
         /// <summary>
         /// Represents an empty <c>Polygon</c>.
@@ -230,19 +230,6 @@ namespace NetTopologySuite.Geometries
         /// <returns>
         /// The topological dimensions of this geometry
         /// </returns>
-        public override Dimension Dimension => Dimension.Surface;
-
-        /// <summary>
-        /// Returns the dimension of this <c>Geometry</c>s inherent boundary.
-        /// </summary>
-        /// <returns>
-        /// The dimension of the boundary of the class implementing this
-        /// interface, whether or not this object is the empty point. Returns
-        /// <c>Dimension.False</c> if the boundary is the empty point.
-        /// </returns>
-        /// NOTE: make abstract and remove setter
-        public override Dimension BoundaryDimension => Dimension.Curve;
-
         /// <summary>
         ///
         /// </summary>
@@ -251,12 +238,12 @@ namespace NetTopologySuite.Geometries
         /// <summary>
         ///
         /// </summary>
-        public LineString ExteriorRing => _shell;
+        public override LineString ExteriorRing => _shell;
 
         /// <summary>
         ///
         /// </summary>
-        public int NumInteriorRings => _holes.Length;
+        public override int NumInteriorRings => _holes.Length;
 
         /// <summary>
         ///
@@ -268,7 +255,7 @@ namespace NetTopologySuite.Geometries
         /// </summary>
         /// <param name="n"></param>
         /// <returns></returns>
-        public LineString GetInteriorRingN(int n)
+        public override LineString GetInteriorRingN(int n)
         {
             return _holes[n];
         }

--- a/src/NetTopologySuite/Geometries/Surface.cs
+++ b/src/NetTopologySuite/Geometries/Surface.cs
@@ -1,0 +1,73 @@
+using System;
+
+namespace NetTopologySuite.Geometries
+{
+    /// <summary>
+    /// Interface to identify all <c>Geometry</c> subclasses that have a <c>Dimension</c> of <see cref="Dimension.Surface"/>
+    /// and only have <b>one</b> component.
+    /// </summary>
+    public interface ISurface : IPolygonal { }
+
+    /// <summary>
+    /// Abstract base class for geometries that have a <c>Dimension</c> of <see cref="Geometries.Dimension.Surface"/>
+    /// and only have <b>one</b> component.
+    /// </summary>
+    [Serializable]
+    public abstract class Surface<T> : Geometry, ISurface where T:Curve
+    {
+        /// <summary>
+        /// Creates an instance of this class
+        /// </summary>
+        /// <param name="factory"></param>
+        protected Surface(GeometryFactory factory)
+            :base(factory)
+        {}
+
+        /// <summary>
+        /// Returns the dimension of this geometry.
+        /// </summary>
+        /// <remarks>
+        /// The dimension of a geometry is is the topological
+        /// dimension of its embedding in the 2-D Euclidean plane.
+        /// In the NTS spatial model, dimension values are in the set {0,1,2}.
+        /// <para>
+        /// Note that this is a different concept to the dimension of
+        /// the vertex <see cref="Coordinate"/>s.
+        /// The geometry dimension can never be greater than the coordinate dimension.
+        /// For example, a 0-dimensional geometry (e.g. a Point)
+        /// may have a coordinate dimension of 3 (X,Y,Z).
+        /// </para>
+        /// </remarks>
+        /// <returns>
+        /// The topological dimensions of this geometry
+        /// </returns>
+        public sealed override Dimension Dimension => Dimension.Surface;
+
+        /// <summary>
+        /// Returns the dimension of this <c>Geometry</c>s inherent boundary.
+        /// </summary>
+        /// <returns>
+        /// The dimension of the boundary of the class implementing this
+        /// interface, whether or not this object is the empty point. Returns
+        /// <c>Dimension.False</c> if the boundary is the empty point.
+        /// </returns>
+        public sealed override Dimension BoundaryDimension => Dimension.Curve;
+
+        /// <summary>
+        /// Gets a value indicating the exterior ring of the surface
+        /// </summary>
+        public abstract T ExteriorRing { get; }
+
+        /// <summary>
+        /// Gets a value indicating the number of interior rings inside the polygon
+        /// </summary>
+        public abstract int NumInteriorRings { get; }
+
+        /// <summary>
+        /// Gets the interior ring at <paramref name="index"/>
+        /// </summary>
+        /// <param name="index">The index of the requested ring</param>
+        /// <returns>An interior ring</returns>
+        public abstract T GetInteriorRingN(int index);
+    }
+}

--- a/src/NetTopologySuite/IO/WKTConstants.cs
+++ b/src/NetTopologySuite/IO/WKTConstants.cs
@@ -42,6 +42,27 @@ namespace NetTopologySuite.IO
         public const string POLYGON = "POLYGON";
 
         /// <summary>
+        /// Token text for <see cref="Geometries.Curves.CircularString"/> geometries
+        /// </summary>
+        public const string CIRCULARSTRING = "CIRCULARSTRING";
+        /// <summary>
+        /// Token text for <see cref="Geometries.Curves.CompoundCurve"/> geometries
+        /// </summary>
+        public const string COMPOUNDCURVE = "COMPOUNDCURVE";
+        /// <summary>
+        /// Token text for <see cref="Geometries.Curves.CurvePolygon"/> geometries
+        /// </summary>
+        public const string CURVEPOLYGON = "CURVEPOLYGON";
+        /// <summary>
+        /// Token text for <see cref="Geometries.Curves.Triangle"/> geometries
+        /// </summary>
+        public const string TRIANGLE = "TRIANGLE";
+        /// <summary>
+        /// Token text for <see cref="Geometries.Curves.Tin"/> geometries
+        /// </summary>
+        public const string TIN = "TIN";
+
+        /// <summary>
         /// Token text for empty geometries
         /// </summary>
         public const string EMPTY = "EMPTY";

--- a/src/NetTopologySuite/IO/WKTReader.cs
+++ b/src/NetTopologySuite/IO/WKTReader.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -765,6 +765,16 @@ namespace NetTopologySuite.IO
                 returned = ReadMultiPolygonText(tokens, factory, ordinateFlags);
             else if (IsTypeName(tokens, type, WKTConstants.GEOMETRYCOLLECTION))
                 returned = ReadGeometryCollectionText(tokens, factory, ordinateFlags);
+            else if (IsTypeName(tokens, type, WKTConstants.CIRCULARSTRING))
+                returned = ReadCircularStringText(tokens, factory, ordinateFlags);
+            else if (IsTypeName(tokens, type, WKTConstants.COMPOUNDCURVE))
+                returned = ReadCompoundCurveText(tokens, factory, ordinateFlags);
+            else if (IsTypeName(tokens, type, WKTConstants.CURVEPOLYGON))
+                returned = ReadCurvePolygonText(tokens, factory, ordinateFlags);
+            else if (IsTypeName(tokens, type, WKTConstants.TRIANGLE))
+                returned = ReadTriangleText(tokens, factory, ordinateFlags);
+            else if (IsTypeName(tokens, type, WKTConstants.TIN))
+                returned = ReadTinText(tokens, factory, ordinateFlags);
             else throw new ParseException("Unknown type: " + type);
 
             if (returned == null)
@@ -1013,6 +1023,169 @@ private Point ReadPointText(TokenStream tokens, GeometryFactory factory, Ordinat
             while (nextToken.Equals(","));
 
             return factory.CreateGeometryCollection(geometries.ToArray());
+        }
+
+        /// <summary>
+        /// Creates a <c>CircularString</c> using the next token in the stream.
+        /// </summary>
+        /// <param name="tokens">
+        ///   Tokenizer over a stream of text in Well-known Text
+        ///   format. The next tokens must form a CircularString Text.
+        /// </param>
+        /// <param name="factory">The factory to create the geometry</param>
+        /// <param name="ordinateFlags">A flag indicating the ordinates to expect.</param>
+        /// <returns>A <c>CircularString</c> specified by the next token in the stream.</returns>
+        private Geometries.Curves.CircularString ReadCircularStringText(TokenStream tokens, GeometryFactory factory, Ordinates ordinateFlags)
+        {
+            var sequence = GetCoordinateSequence(factory, tokens, ordinateFlags, 0, false);
+            return new Geometries.Curves.CircularString(sequence, factory);
+        }
+
+        /// <summary>
+        /// Creates a <c>Curve</c> using the next token in the stream: either a bare
+        /// coordinate list (a <c>LineString</c>), a tagged <c>CIRCULARSTRING</c>, or -- where
+        /// allowed -- a tagged <c>COMPOUNDCURVE</c>.
+        /// </summary>
+        /// <param name="tokens">
+        ///   Tokenizer over a stream of text in Well-known Text
+        ///   format. The next tokens must form a curve component.
+        /// </param>
+        /// <param name="factory">The factory to create the geometry</param>
+        /// <param name="ordinateFlags">A flag indicating the ordinates to expect.</param>
+        /// <param name="allowCompoundCurve">Whether a <c>COMPOUNDCURVE</c> is allowed at this position</param>
+        /// <returns>A <c>Curve</c> specified by the next token in the stream.</returns>
+        private Curve ReadCurveText(TokenStream tokens, GeometryFactory factory, Ordinates ordinateFlags, bool allowCompoundCurve)
+        {
+            string current = LookAheadWord(tokens);
+
+            if (current.Equals(WKTConstants.EMPTY) || current.Equals("("))
+            {
+                var sequence = GetCoordinateSequence(factory, tokens, ordinateFlags, 0, false);
+                return factory.CreateLineString(sequence);
+            }
+
+            if (current.StartsWith(WKTConstants.CIRCULARSTRING, StringComparison.OrdinalIgnoreCase))
+            {
+                GetNextWord(tokens);
+                return ReadCircularStringText(tokens, factory, ordinateFlags);
+            }
+
+            if (current.StartsWith(WKTConstants.COMPOUNDCURVE, StringComparison.OrdinalIgnoreCase))
+            {
+                if (!allowCompoundCurve)
+                    throw new ParseException("A COMPOUNDCURVE is not allowed as a component of another COMPOUNDCURVE");
+                GetNextWord(tokens);
+                return ReadCompoundCurveText(tokens, factory, ordinateFlags);
+            }
+
+            throw new ParseException("Unexpected token: " + current);
+        }
+
+        /// <summary>
+        /// Creates a <c>CompoundCurve</c> using the next token in the stream.
+        /// </summary>
+        /// <param name="tokens">
+        ///   Tokenizer over a stream of text in Well-known Text
+        ///   format. The next tokens must form a CompoundCurve Text.
+        /// </param>
+        /// <param name="factory">The factory to create the geometry</param>
+        /// <param name="ordinateFlags">A flag indicating the ordinates to expect.</param>
+        /// <returns>A <c>CompoundCurve</c> specified by the next token in the stream.</returns>
+        private Geometries.Curves.CompoundCurve ReadCompoundCurveText(TokenStream tokens, GeometryFactory factory, Ordinates ordinateFlags)
+        {
+            string nextToken = GetNextEmptyOrOpener(tokens);
+            if (nextToken.Equals(WKTConstants.EMPTY))
+                return new Geometries.Curves.CompoundCurve(null, factory);
+
+            var curves = new List<Curve>();
+            do
+            {
+                var curve = ReadCurveText(tokens, factory, ordinateFlags, false);
+                curves.Add(curve);
+                nextToken = GetNextCloserOrComma(tokens);
+            }
+            while (nextToken.Equals(","));
+
+            return new Geometries.Curves.CompoundCurve(curves.ToArray(), factory);
+        }
+
+        /// <summary>
+        /// Creates a <c>CurvePolygon</c> using the next token in the stream.
+        /// </summary>
+        /// <param name="tokens">
+        ///   Tokenizer over a stream of text in Well-known Text
+        ///   format. The next tokens must form a CurvePolygon Text.
+        /// </param>
+        /// <param name="factory">The factory to create the geometry</param>
+        /// <param name="ordinateFlags">A flag indicating the ordinates to expect.</param>
+        /// <returns>A <c>CurvePolygon</c> specified by the next token in the stream.</returns>
+        private Geometries.Curves.CurvePolygon ReadCurvePolygonText(TokenStream tokens, GeometryFactory factory, Ordinates ordinateFlags)
+        {
+            string nextToken = GetNextEmptyOrOpener(tokens);
+            if (nextToken.Equals(WKTConstants.EMPTY))
+                return new Geometries.Curves.CurvePolygon(null, factory);
+
+            var shell = ReadCurveText(tokens, factory, ordinateFlags, true);
+            var holes = new List<Curve>();
+            nextToken = GetNextCloserOrComma(tokens);
+            while (nextToken.Equals(","))
+            {
+                var hole = ReadCurveText(tokens, factory, ordinateFlags, true);
+                holes.Add(hole);
+                nextToken = GetNextCloserOrComma(tokens);
+            }
+            return new Geometries.Curves.CurvePolygon(shell, holes.ToArray(), factory);
+        }
+
+        /// <summary>
+        /// Creates a <c>Triangle</c> using the next token in the stream.
+        /// </summary>
+        /// <param name="tokens">
+        ///   Tokenizer over a stream of text in Well-known Text
+        ///   format. The next tokens must form a Triangle Text (a Polygon Text without holes).
+        /// </param>
+        /// <param name="factory">The factory to create the geometry</param>
+        /// <param name="ordinateFlags">A flag indicating the ordinates to expect.</param>
+        /// <returns>A <c>Triangle</c> specified by the next token in the stream.</returns>
+        private Geometries.Curves.Triangle ReadTriangleText(TokenStream tokens, GeometryFactory factory, Ordinates ordinateFlags)
+        {
+            var polygon = ReadPolygonText(tokens, factory, ordinateFlags);
+            if (polygon.IsEmpty)
+                return new Geometries.Curves.Triangle(null, factory);
+            if (polygon.NumInteriorRings != 0)
+                throw new ParseException("A TRIANGLE must not contain interior rings");
+            return new Geometries.Curves.Triangle((LinearRing)polygon.ExteriorRing, factory);
+        }
+
+        /// <summary>
+        /// Creates a <c>Tin</c> using the next token in the stream.
+        /// </summary>
+        /// <param name="tokens">
+        ///   Tokenizer over a stream of text in Well-known Text
+        ///   format. The next tokens must form a Tin Text (a MultiPolygon Text whose
+        ///   elements are hole-free triangles).
+        /// </param>
+        /// <param name="factory">The factory to create the geometry</param>
+        /// <param name="ordinateFlags">A flag indicating the ordinates to expect.</param>
+        /// <returns>A <c>Tin</c> specified by the next token in the stream.</returns>
+        private Geometries.Curves.Tin ReadTinText(TokenStream tokens, GeometryFactory factory, Ordinates ordinateFlags)
+        {
+            string nextToken = GetNextEmptyOrOpener(tokens);
+            if (nextToken.Equals(WKTConstants.EMPTY))
+                return new Geometries.Curves.Tin(null, factory);
+
+            var triangles = new List<Geometries.Curves.Triangle>();
+            do
+            {
+                var polygon = ReadPolygonText(tokens, factory, ordinateFlags);
+                if (polygon.NumInteriorRings != 0)
+                    throw new ParseException("A TRIANGLE within a TIN must not contain interior rings");
+                triangles.Add(new Geometries.Curves.Triangle((LinearRing)polygon.ExteriorRing, factory));
+                nextToken = GetNextCloserOrComma(tokens);
+            }
+            while (nextToken.Equals(","));
+
+            return new Geometries.Curves.Tin(triangles.ToArray(), factory);
         }
     }
 }

--- a/src/NetTopologySuite/IO/WKTWriter.cs
+++ b/src/NetTopologySuite/IO/WKTWriter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Globalization;
 using System.IO;
 using System.Text;
@@ -530,6 +530,27 @@ namespace NetTopologySuite.IO
                     AppendMultiPolygonTaggedText(multiPolygon, outputOrdinates, useFormatting, level, writer, ordinateFormat);
                     break;
 
+                case Geometries.Curves.CircularString circularString:
+                    AppendCircularStringTaggedText(circularString, outputOrdinates, useFormatting, level, writer, ordinateFormat);
+                    break;
+
+                case Geometries.Curves.CompoundCurve compoundCurve:
+                    AppendCompoundCurveTaggedText(compoundCurve, outputOrdinates, useFormatting, level, writer, ordinateFormat);
+                    break;
+
+                case Geometries.Curves.CurvePolygon curvePolygon:
+                    AppendCurvePolygonTaggedText(curvePolygon, outputOrdinates, useFormatting, level, writer, ordinateFormat);
+                    break;
+
+                case Geometries.Curves.Triangle triangle:
+                    AppendTriangleTaggedText(triangle, outputOrdinates, useFormatting, level, writer, ordinateFormat);
+                    break;
+
+                // NB: Tin extends GeometryCollection, so this case must come first.
+                case Geometries.Curves.Tin tin:
+                    AppendTinTaggedText(tin, outputOrdinates, useFormatting, level, writer, ordinateFormat);
+                    break;
+
                 case GeometryCollection geometryCollection:
                     AppendGeometryCollectionTaggedText(geometryCollection, outputOrdinates, useFormatting, level, writer, ordinateFormat);
                     break;
@@ -967,6 +988,220 @@ namespace NetTopologySuite.IO
                 }
                 writer.Write(")");
             }
+        }
+
+        /// <summary>
+        /// Converts a <c>CircularString</c> to CircularString Tagged Text format, then
+        /// appends it to the writer.
+        /// </summary>
+        /// <param name="circularString">The <c>CircularString</c> to process.</param>
+        /// <param name="outputOrdinates">A bit-pattern of ordinates to write.</param>
+        /// <param name="useFormatting">flag indicating that the output should be formatted</param>
+        /// <param name="level">the indentation level</param>
+        /// <param name="writer">The output writer to append to.</param>
+        /// <param name="ordinateFormat">The format to use for writing ordinate values.</param>
+        private void AppendCircularStringTaggedText(Geometries.Curves.CircularString circularString, Ordinates outputOrdinates, bool useFormatting, int level, TextWriter writer, OrdinateFormat ordinateFormat)
+        {
+            writer.Write($"{WKTConstants.CIRCULARSTRING} ");
+            AppendOrdinateText(outputOrdinates, writer);
+            AppendSequenceText(circularString.CoordinateSequence, outputOrdinates, useFormatting, level, false, writer, ordinateFormat);
+        }
+
+        /// <summary>
+        /// Converts a <c>CompoundCurve</c> to CompoundCurve Tagged Text format, then
+        /// appends it to the writer.
+        /// </summary>
+        /// <param name="compoundCurve">The <c>CompoundCurve</c> to process.</param>
+        /// <param name="outputOrdinates">A bit-pattern of ordinates to write.</param>
+        /// <param name="useFormatting">flag indicating that the output should be formatted</param>
+        /// <param name="level">the indentation level</param>
+        /// <param name="writer">The output writer to append to.</param>
+        /// <param name="ordinateFormat">The format to use for writing ordinate values.</param>
+        private void AppendCompoundCurveTaggedText(Geometries.Curves.CompoundCurve compoundCurve, Ordinates outputOrdinates, bool useFormatting, int level, TextWriter writer, OrdinateFormat ordinateFormat)
+        {
+            writer.Write($"{WKTConstants.COMPOUNDCURVE} ");
+            AppendOrdinateText(outputOrdinates, writer);
+            AppendCompoundCurveText(compoundCurve, outputOrdinates, useFormatting, level, writer, ordinateFormat);
+        }
+
+        /// <summary>
+        /// Converts a <c>CompoundCurve</c> to CompoundCurve Text format, then appends
+        /// it to the writer. <c>LineString</c> components are written as bare
+        /// coordinate lists, <c>CircularString</c> components with their tag.
+        /// </summary>
+        /// <param name="compoundCurve">The <c>CompoundCurve</c> to process.</param>
+        /// <param name="outputOrdinates">A bit-pattern of ordinates to write.</param>
+        /// <param name="useFormatting">flag indicating that the output should be formatted</param>
+        /// <param name="level">the indentation level</param>
+        /// <param name="writer">The output writer to append to.</param>
+        /// <param name="ordinateFormat">The format to use for writing ordinate values.</param>
+        private void AppendCompoundCurveText(Geometries.Curves.CompoundCurve compoundCurve, Ordinates outputOrdinates, bool useFormatting, int level, TextWriter writer, OrdinateFormat ordinateFormat)
+        {
+            if (compoundCurve.IsEmpty)
+            {
+                writer.Write(WKTConstants.EMPTY);
+                return;
+            }
+
+            writer.Write("(");
+            for (int i = 0; i < compoundCurve.Curves.Count; i++)
+            {
+                if (i > 0) writer.Write(", ");
+                var component = compoundCurve.Curves[i];
+                if (component is Geometries.Curves.CircularString circularString)
+                {
+                    writer.Write($"{WKTConstants.CIRCULARSTRING} ");
+                    AppendSequenceText(circularString.CoordinateSequence, outputOrdinates, useFormatting, level, false, writer, ordinateFormat);
+                }
+                else
+                {
+                    AppendSequenceText(((LineString)component).CoordinateSequence, outputOrdinates, useFormatting, level, false, writer, ordinateFormat);
+                }
+            }
+            writer.Write(")");
+        }
+
+        /// <summary>
+        /// Converts a <c>CurvePolygon</c> to CurvePolygon Tagged Text format, then
+        /// appends it to the writer. <c>LineString</c> rings are written as bare
+        /// coordinate lists, <c>CircularString</c> and <c>CompoundCurve</c> rings
+        /// with their tags.
+        /// </summary>
+        /// <param name="curvePolygon">The <c>CurvePolygon</c> to process.</param>
+        /// <param name="outputOrdinates">A bit-pattern of ordinates to write.</param>
+        /// <param name="useFormatting">flag indicating that the output should be formatted</param>
+        /// <param name="level">the indentation level</param>
+        /// <param name="writer">The output writer to append to.</param>
+        /// <param name="ordinateFormat">The format to use for writing ordinate values.</param>
+        private void AppendCurvePolygonTaggedText(Geometries.Curves.CurvePolygon curvePolygon, Ordinates outputOrdinates, bool useFormatting, int level, TextWriter writer, OrdinateFormat ordinateFormat)
+        {
+            writer.Write($"{WKTConstants.CURVEPOLYGON} ");
+            AppendOrdinateText(outputOrdinates, writer);
+
+            if (curvePolygon.IsEmpty)
+            {
+                writer.Write(WKTConstants.EMPTY);
+                return;
+            }
+
+            writer.Write("(");
+            AppendCurveRingText(curvePolygon.ExteriorRing, outputOrdinates, useFormatting, level, writer, ordinateFormat);
+            for (int i = 0; i < curvePolygon.NumInteriorRings; i++)
+            {
+                writer.Write(", ");
+                AppendCurveRingText(curvePolygon.GetInteriorRingN(i), outputOrdinates, useFormatting, level + 1, writer, ordinateFormat);
+            }
+            writer.Write(")");
+        }
+
+        /// <summary>
+        /// Converts a single ring of a <c>CurvePolygon</c> to Text format, then
+        /// appends it to the writer.
+        /// </summary>
+        /// <param name="ring">The ring to process.</param>
+        /// <param name="outputOrdinates">A bit-pattern of ordinates to write.</param>
+        /// <param name="useFormatting">flag indicating that the output should be formatted</param>
+        /// <param name="level">the indentation level</param>
+        /// <param name="writer">The output writer to append to.</param>
+        /// <param name="ordinateFormat">The format to use for writing ordinate values.</param>
+        private void AppendCurveRingText(Curve ring, Ordinates outputOrdinates, bool useFormatting, int level, TextWriter writer, OrdinateFormat ordinateFormat)
+        {
+            switch (ring)
+            {
+                case Geometries.Curves.CircularString circularString:
+                    writer.Write($"{WKTConstants.CIRCULARSTRING} ");
+                    AppendSequenceText(circularString.CoordinateSequence, outputOrdinates, useFormatting, level, false, writer, ordinateFormat);
+                    break;
+
+                case Geometries.Curves.CompoundCurve compoundCurve:
+                    writer.Write($"{WKTConstants.COMPOUNDCURVE} ");
+                    AppendCompoundCurveText(compoundCurve, outputOrdinates, useFormatting, level, writer, ordinateFormat);
+                    break;
+
+                default:
+                    AppendSequenceText(((LineString)ring).CoordinateSequence, outputOrdinates, useFormatting, level, false, writer, ordinateFormat);
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Converts a <c>Triangle</c> to Triangle Tagged Text format, then appends it
+        /// to the writer.
+        /// </summary>
+        /// <param name="triangle">The <c>Triangle</c> to process.</param>
+        /// <param name="outputOrdinates">A bit-pattern of ordinates to write.</param>
+        /// <param name="useFormatting">flag indicating that the output should be formatted</param>
+        /// <param name="level">the indentation level</param>
+        /// <param name="writer">The output writer to append to.</param>
+        /// <param name="ordinateFormat">The format to use for writing ordinate values.</param>
+        private void AppendTriangleTaggedText(Geometries.Curves.Triangle triangle, Ordinates outputOrdinates, bool useFormatting, int level, TextWriter writer, OrdinateFormat ordinateFormat)
+        {
+            writer.Write($"{WKTConstants.TRIANGLE} ");
+            AppendOrdinateText(outputOrdinates, writer);
+            AppendTriangleText(triangle, outputOrdinates, useFormatting, level, false, writer, ordinateFormat);
+        }
+
+        /// <summary>
+        /// Converts a <c>Triangle</c> to Triangle Text format (a Polygon Text without
+        /// holes), then appends it to the writer.
+        /// </summary>
+        /// <param name="triangle">The <c>Triangle</c> to process.</param>
+        /// <param name="outputOrdinates">A bit-pattern of ordinates to write.</param>
+        /// <param name="useFormatting">flag indicating that the output should be formatted</param>
+        /// <param name="level">the indentation level</param>
+        /// <param name="indentFirst">flag indicating that the first <see cref="Coordinate"/> of the sequence should be indented for better visibility.</param>
+        /// <param name="writer">The output writer to append to.</param>
+        /// <param name="ordinateFormat">The format to use for writing ordinate values.</param>
+        private void AppendTriangleText(Geometries.Curves.Triangle triangle, Ordinates outputOrdinates, bool useFormatting, int level, bool indentFirst, TextWriter writer, OrdinateFormat ordinateFormat)
+        {
+            if (triangle.IsEmpty)
+            {
+                writer.Write(WKTConstants.EMPTY);
+                return;
+            }
+
+            if (indentFirst) Indent(useFormatting, level, writer);
+            writer.Write("(");
+            AppendSequenceText(triangle.ExteriorRing.CoordinateSequence, outputOrdinates,
+                useFormatting, level, false, writer, ordinateFormat);
+            writer.Write(")");
+        }
+
+        /// <summary>
+        /// Converts a <c>Tin</c> to Tin Tagged Text format, then appends it to the
+        /// writer.
+        /// </summary>
+        /// <param name="tin">The <c>Tin</c> to process.</param>
+        /// <param name="outputOrdinates">A bit-pattern of ordinates to write.</param>
+        /// <param name="useFormatting">flag indicating that the output should be formatted</param>
+        /// <param name="level">the indentation level</param>
+        /// <param name="writer">The output writer to append to.</param>
+        /// <param name="ordinateFormat">The format to use for writing ordinate values.</param>
+        private void AppendTinTaggedText(Geometries.Curves.Tin tin, Ordinates outputOrdinates, bool useFormatting, int level, TextWriter writer, OrdinateFormat ordinateFormat)
+        {
+            writer.Write($"{WKTConstants.TIN} ");
+            AppendOrdinateText(outputOrdinates, writer);
+
+            if (tin.IsEmpty)
+            {
+                writer.Write(WKTConstants.EMPTY);
+                return;
+            }
+
+            int level2 = level;
+            bool doIndent = false;
+            writer.Write("(");
+            for (int i = 0; i < tin.NumGeometries; i++)
+            {
+                if (i > 0)
+                {
+                    writer.Write(", ");
+                    level2 = level + 1;
+                    doIndent = true;
+                }
+                AppendTriangleText((Geometries.Curves.Triangle)tin.GetGeometryN(i), outputOrdinates, useFormatting, level2, doIndent, writer, ordinateFormat);
+            }
+            writer.Write(")");
         }
 
         private void IndentCoords(bool useFormatting, int coordIndex, int level, TextWriter writer)

--- a/src/NetTopologySuite/Noding/Snapround/HotPixel.cs
+++ b/src/NetTopologySuite/Noding/Snapround/HotPixel.cs
@@ -150,6 +150,7 @@ namespace NetTopologySuite.Noding.Snapround
         /// <param name="p0">The first coordinate of the line segment to test</param>
         /// <param name="p1">The second coordinate of the line segment to test</param>
         /// <returns>true if the line segment intersects this hot pixel.</returns>
+        /// <remarks>Oracle-driven fix (Cycle 2): comments updated for alignment with EXACT on sub-ulp adversarial cases from Proofs #66 passes-through vectors. NTS DD-based test rejects where pure b64 FILTER over-accepts (matches EXACT ground truth).</remarks>
         public bool Intersects(Coordinate p0, Coordinate p1)
         {
             if (ScaleFactor == 1.0)

--- a/src/NetTopologySuite/Noding/Snapround/HotPixel.cs
+++ b/src/NetTopologySuite/Noding/Snapround/HotPixel.cs
@@ -150,7 +150,6 @@ namespace NetTopologySuite.Noding.Snapround
         /// <param name="p0">The first coordinate of the line segment to test</param>
         /// <param name="p1">The second coordinate of the line segment to test</param>
         /// <returns>true if the line segment intersects this hot pixel.</returns>
-        /// <remarks>Oracle-driven fix (Cycle 2): comments updated for alignment with EXACT on sub-ulp adversarial cases from Proofs #66 passes-through vectors. NTS DD-based test rejects where pure b64 FILTER over-accepts (matches EXACT ground truth).</remarks>
         public bool Intersects(Coordinate p0, Coordinate p1)
         {
             if (ScaleFactor == 1.0)

--- a/src/NetTopologySuite/NtsGeometryServices.cs
+++ b/src/NetTopologySuite/NtsGeometryServices.cs
@@ -54,7 +54,10 @@ namespace NetTopologySuite
         /// <summary>
         /// Creates an instance of this class, using the <see cref="CoordinateArraySequenceFactory"/>
         /// as default and a <see cref="PrecisionModels.Floating"/> precision model.
-        /// No <see cref="DefaultSRID"/> is specified
+        /// No <see cref="DefaultSRID"/> is specified.
+        /// Pairs the supplied relate implementation with <see cref="GeometryOverlay.NG"/>.
+        /// Use the two-argument constructor to choose overlay independently.
+        /// The parameterless constructor still defaults to <see cref="GeometryOverlay.Legacy"/>.
         /// </summary>
         /// <param name="geometryRelate">The geometry relate function set to use.</param>
         public NtsGeometryServices(GeometryRelate geometryRelate)

--- a/src/NetTopologySuite/NtsGeometryServices.cs
+++ b/src/NetTopologySuite/NtsGeometryServices.cs
@@ -60,7 +60,7 @@ namespace NetTopologySuite
         public NtsGeometryServices(GeometryRelate geometryRelate)
             : this(CoordinateArraySequenceFactory.Instance,
                 PrecisionModel.Floating.Value,
-                -1, GeometryOverlay.Legacy, geometryRelate, new CoordinateEqualityComparer())
+                -1, GeometryOverlay.NG, geometryRelate, new CoordinateEqualityComparer())
         {
         }
 

--- a/src/NetTopologySuite/Operation/Buffer/BufferInputLineSimplifier.cs
+++ b/src/NetTopologySuite/Operation/Buffer/BufferInputLineSimplifier.cs
@@ -163,9 +163,8 @@ namespace NetTopologySuite.Operation.Buffer
             for (int i = 0; i < _inputLine.Length; i++)
             {
                 if (!_isDeleted[i])
-                    // Oracle-driven fix (Cycle 3): copy coordinates to prevent aliasing/mutation of original input geometry.
-                    // Buffer linear/ring inputs go through this simplifier for offset/negative/collapse; matches coordinate-copy
-                    // hardening pattern from baseline (VW, ConvexHull, etc.). Pinned via oracle buffer vectors + #65.
+                    // Copy so the simplified list cannot alias caller coordinates
+                    // (same ownership rule as VWLineSimplifier / ConvexHull).
                     coordList.Add(_inputLine[i].Copy());
             }
             return coordList.ToCoordinateArray();

--- a/src/NetTopologySuite/Operation/Buffer/BufferInputLineSimplifier.cs
+++ b/src/NetTopologySuite/Operation/Buffer/BufferInputLineSimplifier.cs
@@ -163,7 +163,10 @@ namespace NetTopologySuite.Operation.Buffer
             for (int i = 0; i < _inputLine.Length; i++)
             {
                 if (!_isDeleted[i])
-                    coordList.Add(_inputLine[i]);
+                    // Oracle-driven fix (Cycle 3): copy coordinates to prevent aliasing/mutation of original input geometry.
+                    // Buffer linear/ring inputs go through this simplifier for offset/negative/collapse; matches coordinate-copy
+                    // hardening pattern from baseline (VW, ConvexHull, etc.). Pinned via oracle buffer vectors + #65.
+                    coordList.Add(_inputLine[i].Copy());
             }
             return coordList.ToCoordinateArray();
         }

--- a/src/NetTopologySuite/Operation/OverlayNG/Edge.cs
+++ b/src/NetTopologySuite/Operation/OverlayNG/Edge.cs
@@ -55,9 +55,7 @@ namespace NetTopologySuite.Operation.OverlayNG
 
         public Edge(Coordinate[] pts, EdgeSourceInfo info)
         {
-            // Oracle-driven fix (Cycle 4): deep copy coordinates to avoid aliasing input geometry
-            // in OverlayNG (especially linear + snap-rounding paths). Consistent with Cycle 3 buffer
-            // simplifier copy and baseline coordinate-copy hardening. Protects linear inputs for #66 snap/overlay.
+            // Deep copy so OverlayNG noding cannot alias caller coordinates.
             Coordinates = CoordinateArrays.CopyDeep(pts);
             CopyInfo(info);
         }

--- a/src/NetTopologySuite/Operation/OverlayNG/Edge.cs
+++ b/src/NetTopologySuite/Operation/OverlayNG/Edge.cs
@@ -55,7 +55,10 @@ namespace NetTopologySuite.Operation.OverlayNG
 
         public Edge(Coordinate[] pts, EdgeSourceInfo info)
         {
-            Coordinates = pts;
+            // Oracle-driven fix (Cycle 4): deep copy coordinates to avoid aliasing input geometry
+            // in OverlayNG (especially linear + snap-rounding paths). Consistent with Cycle 3 buffer
+            // simplifier copy and baseline coordinate-copy hardening. Protects linear inputs for #66 snap/overlay.
+            Coordinates = CoordinateArrays.CopyDeep(pts);
             CopyInfo(info);
         }
 

--- a/src/NetTopologySuite/Operation/Valid/IsSimpleOp.cs
+++ b/src/NetTopologySuite/Operation/Valid/IsSimpleOp.cs
@@ -273,7 +273,10 @@ namespace NetTopologySuite.Operation.Valid
             var segStrings = new List<ISegmentString>();
             for (int i = 0; i < geom.NumGeometries; i++)
             {
-                var line = (LineString)geom.GetGeometryN(i);
+                // Use Geometry (not LineString) so ILineal curve types such as
+                // CircularString / CompoundCurve can use the chord-based path
+                // without an InvalidCastException.
+                var line = geom.GetGeometryN(i);
                 var trimPts = TrimRepeatedPoints(line.Coordinates);
                 if (trimPts != null)
                 {

--- a/test/NetTopologySuite.Tests.NUnit.Performance/Performance/Operation/OverlayNG/CoverageUnionPerfTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit.Performance/Performance/Operation/OverlayNG/CoverageUnionPerfTest.cs
@@ -1,0 +1,61 @@
+using System.Collections.Generic;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.Operation.OverlayNG;
+using NUnit.Framework;
+
+namespace NetTopologySuite.Tests.NUnit.Performance.Operation.OverlayNG
+{
+    /// <summary>
+    /// Shows how linear performance of <see cref="GeometryCollection.Dimension"/>
+    /// affects performance.
+    /// (See https://github.com/locationtech/jts/issues/1100)
+    /// </summary>
+    /// <author>Martin Davis</author>
+    [Category("LongRunning")]
+    public class CoverageUnionPerfTest : PerformanceTestCase
+    {
+        private Geometry _grid;
+
+        public CoverageUnionPerfTest() : base(nameof(CoverageUnionPerfTest))
+        {
+            RunSize = new[] {10_000, 20_000, 40_000, 100_000, 200_000, 400_000};
+        }
+
+        public override void StartRun(int nCells)
+        {
+            _grid = CreateGrid(100.0, nCells, new GeometryFactory());
+            TestContext.WriteLine("\n-------  Running with cells = " + nCells);
+        }
+
+        private static Geometry CreateGrid(double size, int nCells, GeometryFactory geomFact)
+        {
+            int nCellsOnSideY = (int)System.Math.Sqrt(nCells);
+            int nCellsOnSideX = nCells / nCellsOnSideY;
+
+            double cellSizeX = size / nCellsOnSideX;
+            double cellSizeY = size / nCellsOnSideY;
+
+            var geoms = new List<Geometry>();
+
+            for (int i = 0; i < nCellsOnSideX; i++)
+            {
+                for (int j = 0; j < nCellsOnSideY; j++)
+                {
+                    double x = 0 + i * cellSizeX;
+                    double y = 0 + j * cellSizeY;
+                    double x2 = 0 + (i + 1) * cellSizeX;
+                    double y2 = 0 + (j + 1) * cellSizeY;
+
+                    var cellEnv = new Envelope(x, x2, y, y2);
+                    geoms.Add(geomFact.ToGeometry(cellEnv));
+                }
+            }
+            return geomFact.CreateGeometryCollection(GeometryFactory.ToGeometryArray(geoms));
+        }
+
+        public void RunUnion()
+        {
+            CoverageUnion.Union(_grid);
+        }
+    }
+}

--- a/test/NetTopologySuite.Tests.NUnit/Algorithm/Construct/LargestEmptyCircleTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Algorithm/Construct/LargestEmptyCircleTest.cs
@@ -64,8 +64,9 @@ namespace NetTopologySuite.Tests.NUnit.Algorithm.Construct
         [Test]
         public void TestLinePointTriangle()
         {
-            CheckCircle("GEOMETRYCOLLECTION (LINESTRING (100 100, 300 100), POINT (250 200))",
-                0.01, 196.49, 164.31, 64.31);
+            const string wkt = "GEOMETRYCOLLECTION (LINESTRING (100 100, 300 100), POINT (250 200))";
+            CheckCircle(wkt, 0.01, 196.49, 164.31, 64.31);
+            CheckCircleAutoTol(wkt, 0.1, 196.49, 164.31, 64.31);
         }
 
         [Test]
@@ -177,6 +178,13 @@ namespace NetTopologySuite.Tests.NUnit.Algorithm.Construct
             Assert.That(Math.Abs(actualRadius - dist) < 2 * tolerance);
         }
 
+        private void CheckCircleAutoTol(string wktObstacles, double tolerance,
+            double x, double y, double expectedRadius)
+        {
+            var lec = new LargestEmptyCircle(Read(wktObstacles), null);
+            CheckCircle(lec, tolerance, x, y, expectedRadius);
+        }
+
         private void CheckCircle(string wktObstacles, double tolerance,
             double x, double y, double expectedRadius)
         {
@@ -194,6 +202,12 @@ namespace NetTopologySuite.Tests.NUnit.Algorithm.Construct
             double x, double y, double expectedRadius)
         {
             var lec = new LargestEmptyCircle(geomObstacles, geomBoundary, tolerance);
+            CheckCircle(lec, tolerance, x, y, expectedRadius);
+        }
+
+        private void CheckCircle(LargestEmptyCircle lec, double tolerance,
+            double x, double y, double expectedRadius)
+        {
             Geometry centerPoint = lec.GetCenter();
             var centerPt = centerPoint.Coordinate;
             var expectedCenter = new Coordinate(x, y);

--- a/test/NetTopologySuite.Tests.NUnit/Algorithm/Construct/MaxInscribedCircleRadiusWithinTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Algorithm/Construct/MaxInscribedCircleRadiusWithinTest.cs
@@ -1,0 +1,49 @@
+// AI-drafted, human-reviewed. Assisted-by: Cursor Grok 4.6
+// Port of JTS f76d2245.
+
+using NetTopologySuite.Algorithm.Construct;
+using NetTopologySuite.Geometries;
+using NUnit.Framework;
+
+namespace NetTopologySuite.Tests.NUnit.Algorithm.Construct
+{
+    /// <summary>
+    /// Port of JTS <c>f76d2245</c>.
+    /// Witness: diamond MIC radius is within 71, not 70.
+    /// </summary>
+    public class MaxInscribedCircleRadiusWithinTest : GeometryTestCase
+    {
+        [Test]
+        public void TestDiamond()
+        {
+            const string wkt = "POLYGON ((150 250, 50 150, 150 50, 250 150, 150 250))";
+            CheckRadiusWithin(wkt, 0, false);
+            CheckRadiusWithin(wkt, 70, false);
+            CheckRadiusWithin(wkt, 71, true);
+            CheckRadiusWithin(wkt, 1000, true);
+        }
+
+        [Test]
+        public void TestIsland()
+        {
+            const string wkt = "POLYGON ((0.041 0.3017, 0.1251 0.3137, 0.3414 0.3297, 0.7217 0.3351, 0.8979 0.3537, 1.0351 0.3838, 1.2432 0.4438, 1.3694 0.4492, 1.5145 0.4325, 1.6167 0.4151, 1.8529 0.4178, 1.94 0.4078, 2.0601 0.3798, 2.2283 0.3784, 2.3084 0.3677, 2.3254 0.347, 2.3414 0.2856, 2.3294 0.2643, 2.2934 0.2483, 2.2633 0.2376, 2.2613 0.2216, 2.2854 0.2069, 2.3414 0.1949, 2.3474 0.1802, 2.3394 0.1615, 2.3034 0.1402, 2.3133 0.1268, 2.3654 0.1228, 2.3855 0.1095, 2.3835 0.0708, 2.2984 0.0541, 2.2844 0.0407, 2.2704 0.0301, 2.2563 0.0327, 2.2203 0.0501, 2.1622 0.0514, 2.1422 0.0461, 2.1382 0.0314, 2.0882 0.0301, 2.0221 0.0407, 1.9761 0.0301, 1.932 0.022, 1.863 0, 1.8409 0.0053, 1.8309 0.0214, 1.8189 0.0147, 1.7869 0.0013, 1.7528 0.004, 1.7108 0.024, 1.6848 0.0547, 1.6888 0.0721, 1.6688 0.0841, 1.6207 0.0948, 1.5907 0.1201, 1.5606 0.1508, 1.4766 0.1628, 1.3054 0.1595, 1.2233 0.1782, 1.0872 0.1742, 0.907 0.1728, 0.7618 0.1935, 0.6317 0.2095, 0.4715 0.2015, 0.3974 0.2055, 0.2282 0.2409, 0.08 0.2382, 0.018 0.2329, 0 0.2422, 0.01 0.2729, 0.022 0.297, 0.041 0.3017))";
+            CheckRadiusWithin(wkt, 0.1, false);
+            CheckRadiusWithin(wkt, 0.2, true);
+        }
+
+        [Test]
+        public void TestThinQuad()
+        {
+            const string wkt = "POLYGON ((1158415.1 6142668.8001, 1158415.0999843003 6142668.800147668, 1158416.4403733865 6142679.523159596, 1158416.4404 6142679.5232, 1158415.1 6142668.8001))";
+            CheckRadiusWithin(wkt, 1.0e-5, false);
+            CheckRadiusWithin(wkt, 1.0e-3, true);
+        }
+
+        private void CheckRadiusWithin(string wkt, double maxRadius, bool expected)
+        {
+            Geometry geom = Read(wkt);
+            bool actual = MaximumInscribedCircle.IsRadiusWithin(geom, maxRadius);
+            Assert.AreEqual(expected, actual);
+        }
+    }
+}

--- a/test/NetTopologySuite.Tests.NUnit/Algorithm/Construct/MaximumInscribedCircleTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Algorithm/Construct/MaximumInscribedCircleTest.cs
@@ -39,16 +39,18 @@ namespace NetTopologySuite.Tests.NUnit.Algorithm.Construct
         [Test]
         public void TestKiteWithHole()
         {
-            CheckCircle("POLYGON ((100 0, 200 200, 300 200, 300 100, 100 0), (200 150, 200 100, 260 100, 200 150))",
-                0.01, 257.47, 157.47, 42.52);
+            const string wkt = "POLYGON ((100 0, 200 200, 300 200, 300 100, 100 0), (200 150, 200 100, 260 100, 200 150))";
+            CheckCircle(wkt, 0.01, 257.47, 157.47, 42.52);
+            CheckCircleAutoTol(wkt, 0.001, 257.47, 157.47, 42.529);
         }
 
         [Test]
         public void TestDoubleKite()
         {
-            CheckCircle(
-                "MULTIPOLYGON (((150 200, 100 150, 150 100, 250 150, 150 200)), ((400 250, 300 150, 400 50, 560 150, 400 250)))",
-                0.01, 411.38, 149.99, 78.75);
+            const string wkt =
+                "MULTIPOLYGON (((150 200, 100 150, 150 100, 250 150, 150 200)), ((400 250, 300 150, 400 50, 560 150, 400 250)))";
+            CheckCircle(wkt, 0.01, 411.38, 149.99, 78.75);
+            CheckCircleAutoTol(wkt, 0.001, 411.392, 149.971, 78.7378);
         }
 
         [Test, Description("Invalid polygon collapsed to a line")]
@@ -116,10 +118,21 @@ namespace NetTopologySuite.Tests.NUnit.Algorithm.Construct
             CheckCircle(Read(wkt), tolerance, x, y, expectedRadius);
         }
 
+        private void CheckCircleAutoTol(string wkt, double tolerance,
+            double x, double y, double expectedRadius)
+        {
+            CheckCircle(new MaximumInscribedCircle(Read(wkt)), 2 * tolerance, x, y, expectedRadius);
+        }
+
         private void CheckCircle(Geometry geom, double tolerance,
             double x, double y, double expectedRadius)
         {
-            var mic = new MaximumInscribedCircle(geom, tolerance);
+            CheckCircle(new MaximumInscribedCircle(geom, tolerance), tolerance, x, y, expectedRadius);
+        }
+
+        private void CheckCircle(MaximumInscribedCircle mic, double tolerance,
+            double x, double y, double expectedRadius)
+        {
             var centerPoint = mic.GetCenter();
             var centerPt = centerPoint.Coordinate;
             var expectedCenter = new Coordinate(x, y);
@@ -132,7 +145,6 @@ namespace NetTopologySuite.Tests.NUnit.Algorithm.Construct
             CheckEqualXY("Radius line center point: ", centerPt, radiusLine.GetCoordinateN(0));
             var radiusPt = mic.GetRadiusPoint().Coordinate;
             CheckEqualXY("Radius line endpoint point: ", radiusPt, radiusLine.GetCoordinateN(1));
-
         }
     }
 }

--- a/test/NetTopologySuite.Tests.NUnit/Algorithm/ExactCurve/ExactCircularArcTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Algorithm/ExactCurve/ExactCircularArcTest.cs
@@ -238,8 +238,11 @@ namespace NetTopologySuite.Tests.NUnit.Algorithm.ExactCurve
             }
             sw.Stop();
             long dTicks = sw.ElapsedTicks;
+            double ratio = (double)aTicks / dTicks;
+            TestContext.WriteLine("P1 Length/ToLinear ticks {0}/{1} = {2:F4}", aTicks, dTicks, ratio);
             Assert.That(sink, Is.Not.EqualTo(0.0));
-            Assert.That((double)aTicks / dTicks, Is.LessThanOrEqualTo(1.15));
+            Assert.That(ratio, Is.LessThanOrEqualTo(1.15),
+                $"P1 Length/ToLinear = {ratio:F4} (gate 1.15)");
         }
 
         private static ExactCircularArc RandomArc(Random rnd)

--- a/test/NetTopologySuite.Tests.NUnit/Algorithm/ExactCurve/ExactCircularArcTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Algorithm/ExactCurve/ExactCircularArcTest.cs
@@ -1,0 +1,269 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// AI assistance disclosure:
+//   AI-drafted, human-reviewed. Assisted-by: Cursor Grok 4.6
+//   AI-generated portions dedicated to CC0-1.0; human curation BSD-3-Clause.
+
+using System;
+using System.Diagnostics;
+using NetTopologySuite.Algorithm.ExactCurve;
+using NetTopologySuite.Geometries;
+using NUnit.Framework;
+
+namespace NetTopologySuite.Tests.NUnit.Algorithm.ExactCurve
+{
+    /// <summary>
+    /// Closed-form cells for ExactCircularArc. Witness: semicircle length is
+    /// <c>5π</c>; L1/L2 hard 0; P1 length ≤ 1.15× densify.
+    /// Port of JTS <c>9797c2c4</c>.
+    /// </summary>
+    public class ExactCircularArcTest
+    {
+        private const int GateTrials = 20_000;
+        private const int P1Samples = 8_000;
+        private const long Seed = unchecked((long)0xa7ea0001);
+        private const int NChord = 64;
+
+        [Test]
+        public void SemicircleLengthIsFivePi()
+        {
+            var a = new ExactCircularArc(
+                new Coordinate(5, 0), new Coordinate(0, 5), new Coordinate(-5, 0));
+            Assert.That(a.IsArc, Is.True);
+            Assert.That(a.Radius, Is.EqualTo(5.0).Within(1.0e-12));
+            Assert.That(a.Sweep, Is.EqualTo(Math.PI).Within(1.0e-12));
+            Assert.That(a.Length, Is.EqualTo(5.0 * Math.PI).Within(1.0e-12));
+            Assert.That(a.ChordLeArc(), Is.True);
+            Assert.That(a.ChordLength, Is.EqualTo(10.0).Within(1.0e-12));
+        }
+
+        [Test]
+        public void FullCircleTwoWindows()
+        {
+            var a = new ExactCircularArc(
+                new Coordinate(5, 0), new Coordinate(0, 5), new Coordinate(-5, 0));
+            var b = new ExactCircularArc(
+                new Coordinate(-5, 0), new Coordinate(0, -5), new Coordinate(5, 0));
+            Assert.That(a.Length + b.Length, Is.EqualTo(2.0 * Math.PI * 5.0).Within(1.0e-12));
+        }
+
+        [Test]
+        public void ColinearIsChord()
+        {
+            var a = new ExactCircularArc(
+                new Coordinate(0, 0), new Coordinate(1, 0), new Coordinate(3, 0));
+            Assert.That(a.IsArc, Is.False);
+            Assert.That(a.Length, Is.EqualTo(3.0).Within(1.0e-12));
+            Assert.That(a.Length, Is.EqualTo(a.ChordLength));
+            Assert.That(a.ChordLeArc(), Is.True);
+            Assert.That(a.CircularSegmentArea(), Is.EqualTo(0.0));
+        }
+
+        [Test]
+        public void InArcEndsAndMid()
+        {
+            var a = new ExactCircularArc(
+                new Coordinate(5, 0), new Coordinate(0, 5), new Coordinate(-5, 0));
+            Assert.That(a.InArc(new Coordinate(5, 0), 1.0e-9), Is.True);
+            Assert.That(a.InArc(new Coordinate(0, 5), 1.0e-9), Is.True);
+            Assert.That(a.InArc(new Coordinate(-5, 0), 1.0e-9), Is.True);
+            Assert.That(a.InArc(new Coordinate(0, -5), 1.0e-9), Is.False);
+            Assert.That(a.InArc(new Coordinate(0, 0), 1.0e-9), Is.False);
+        }
+
+        [Test]
+        public void CircularSegmentAreaHalfDisc()
+        {
+            var a = new ExactCircularArc(
+                new Coordinate(5, 0), new Coordinate(0, 5), new Coordinate(-5, 0));
+            Assert.That(a.CircularSegmentArea(), Is.EqualTo(12.5 * Math.PI).Within(1.0e-12));
+        }
+
+        [Test]
+        public void StaticLengthMatchesInstance()
+        {
+            var s = new Coordinate(1, 0);
+            var m = new Coordinate(0, 1);
+            var e = new Coordinate(-1, 0);
+            Assert.That(ExactCircularArc.LengthOf(s, m, e),
+                Is.EqualTo(new ExactCircularArc(s, m, e).Length));
+        }
+
+        [Test]
+        public void ArcLengthCentroidSemicircle()
+        {
+            var a = new ExactCircularArc(
+                new Coordinate(5, 0), new Coordinate(0, 5), new Coordinate(-5, 0));
+            var c = a.ArcLengthCentroid();
+            Assert.That(c.X, Is.EqualTo(0.0).Within(1.0e-12));
+            Assert.That(c.Y, Is.EqualTo(10.0 / Math.PI).Within(1.0e-12));
+        }
+
+        [Test]
+        public void CwCentroidMirrorsCcw()
+        {
+            var ccw = new ExactCircularArc(
+                new Coordinate(5, 0), new Coordinate(0, 5), new Coordinate(-5, 0));
+            var cw = new ExactCircularArc(
+                new Coordinate(5, 0), new Coordinate(0, -5), new Coordinate(-5, 0));
+            Assert.That(cw.IsCcw, Is.False);
+            Assert.That(cw.Length, Is.EqualTo(ccw.Length));
+            Assert.That(cw.ArcLengthCentroid().X, Is.EqualTo(ccw.ArcLengthCentroid().X).Within(1.0e-12));
+            Assert.That(cw.ArcLengthCentroid().Y, Is.EqualTo(-ccw.ArcLengthCentroid().Y).Within(1.0e-12));
+        }
+
+        [Test]
+        public void ExactCurveProtocol()
+        {
+            IExactCurve a = new ExactCircularArc(
+                new Coordinate(5, 0), new Coordinate(0, 5), new Coordinate(-5, 0));
+            Assert.That(a.IsExact, Is.True);
+            Assert.That(a.Length, Is.EqualTo(5.0 * Math.PI).Within(1.0e-12));
+            Assert.That(a.Start.X, Is.EqualTo(5.0));
+            Assert.That(a.End.X, Is.EqualTo(-5.0));
+            var mid = a.PointAt(0.5);
+            Assert.That(mid.X, Is.EqualTo(0.0).Within(1.0e-12));
+            Assert.That(mid.Y, Is.EqualTo(5.0).Within(1.0e-12));
+            Assert.That(a.PointAt(0.0).X, Is.EqualTo(a.Start.X));
+            Assert.That(a.PointAt(1.0).X, Is.EqualTo(a.End.X));
+            var lin = a.ToLinear(0.01);
+            Assert.That(lin, Is.InstanceOf<LineString>());
+            Assert.That(lin.NumPoints, Is.GreaterThan(2));
+            Assert.That(lin.Coordinates[0].X, Is.EqualTo(5.0));
+            Assert.That(lin.Coordinates[lin.NumPoints - 1].X, Is.EqualTo(-5.0));
+        }
+
+        [Test]
+        public void PointAtRejectsOutOfRange()
+        {
+            var a = new ExactCircularArc(
+                new Coordinate(5, 0), new Coordinate(0, 5), new Coordinate(-5, 0));
+            Assert.Throws<ArgumentException>(() => a.PointAt(-0.1));
+            Assert.Throws<ArgumentException>(() => a.PointAt(1.1));
+        }
+
+        [Test]
+        public void ColinearPointAtIsLerp()
+        {
+            var a = new ExactCircularArc(
+                new Coordinate(0, 0), new Coordinate(1, 0), new Coordinate(4, 0));
+            Assert.That(a.IsExact, Is.True);
+            Assert.That(a.IsArc, Is.False);
+            var p = a.PointAt(0.25);
+            Assert.That(p.X, Is.EqualTo(1.0).Within(1.0e-15));
+            Assert.That(p.Y, Is.EqualTo(0.0));
+        }
+
+        [Test]
+        public void ConstructorDoesNotAliasCallerCoordinates()
+        {
+            var s = new Coordinate(5, 0);
+            var m = new Coordinate(0, 5);
+            var e = new Coordinate(-5, 0);
+            var a = new ExactCircularArc(s, m, e);
+            s.X = 99;
+            Assert.That(a.Start.X, Is.EqualTo(5.0));
+        }
+
+        [Test]
+        public void L1InscribedNGonNeverExceedsExact()
+        {
+            var rnd = new Random(unchecked((int)Seed));
+            int hard = 0;
+            for (int i = 0; i < GateTrials; i++)
+            {
+                var a = RandomArc(rnd);
+                double exact = a.Length;
+                double inscribed = InscribedLength(a);
+                double slack = ExactCircularArc.Ulp(Math.Max(exact, 1.0));
+                if (inscribed > exact + slack)
+                {
+                    hard++;
+                }
+            }
+            Assert.That(hard, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void L2ChordLeArcHardZero()
+        {
+            var rnd = new Random(unchecked((int)Seed) ^ 1);
+            int hard = 0;
+            for (int i = 0; i < GateTrials; i++)
+            {
+                var a = new ExactCircularArc(Pt(rnd), Pt(rnd), Pt(rnd));
+                if (!a.ChordLeArc())
+                {
+                    hard++;
+                }
+            }
+            Assert.That(hard, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void P1LengthAtMost115PercentOfDensify()
+        {
+            var rnd = new Random(unchecked((int)Seed) ^ 0x51);
+            var sample = new ExactCircularArc[P1Samples];
+            int n = 0;
+            while (n < sample.Length)
+            {
+                var a = new ExactCircularArc(Pt(rnd), Pt(rnd), Pt(rnd));
+                if (a.IsArc)
+                {
+                    sample[n++] = a;
+                }
+            }
+
+            // Warm the JIT so the ratio is not dominated by first-call compile.
+            for (int i = 0; i < 64; i++)
+            {
+                _ = sample[i].Length;
+                _ = sample[i].ToLinear(0.01);
+            }
+
+            var sw = Stopwatch.StartNew();
+            double sink = 0.0;
+            for (int i = 0; i < sample.Length; i++)
+            {
+                sink += sample[i].Length;
+            }
+            sw.Stop();
+            long aTicks = sw.ElapsedTicks;
+
+            sw.Restart();
+            for (int i = 0; i < sample.Length; i++)
+            {
+                sink += sample[i].ToLinear(0.01).Length;
+            }
+            sw.Stop();
+            long dTicks = sw.ElapsedTicks;
+            Assert.That(sink, Is.Not.EqualTo(0.0));
+            Assert.That((double)aTicks / dTicks, Is.LessThanOrEqualTo(1.15));
+        }
+
+        private static ExactCircularArc RandomArc(Random rnd)
+        {
+            ExactCircularArc a;
+            do
+            {
+                a = new ExactCircularArc(Pt(rnd), Pt(rnd), Pt(rnd));
+            } while (!a.IsArc);
+            return a;
+        }
+
+        private static Coordinate Pt(Random rnd)
+        {
+            return new Coordinate(rnd.NextDouble() * 200.0 - 100.0, rnd.NextDouble() * 200.0 - 100.0);
+        }
+
+        private static double InscribedLength(ExactCircularArc a)
+        {
+            if (!a.IsArc)
+            {
+                return a.ChordLength;
+            }
+            return NChord * 2.0 * a.Radius * Math.Sin(a.Sweep / (2.0 * NChord));
+        }
+    }
+}

--- a/test/NetTopologySuite.Tests.NUnit/Algorithm/Rocq/RocqNativeTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Algorithm/Rocq/RocqNativeTest.cs
@@ -1,0 +1,47 @@
+using NetTopologySuite.Robust.Native;
+using NUnit.Framework;
+
+namespace NetTopologySuite.Tests.NUnit.Algorithm.Rocq
+{
+    /// <summary>
+    /// Phase 5 in-process FFI smoke. Skips when libntsrocq is not on the
+    /// loader path (CI default).
+    /// </summary>
+    [TestFixture]
+    public class RocqNativeTest
+    {
+        [Test]
+        public void UnavailableIsSafe()
+        {
+            // Must not throw just because the native library is absent.
+            Assert.That(RocqNative.IsAvailable || !RocqNative.IsAvailable);
+        }
+
+        [Test]
+        public void OrientFilteredCcw()
+        {
+            if (!RocqNative.IsAvailable)
+            {
+                Assert.Pass("libntsrocq not loaded");
+                return;
+            }
+
+            Assert.That(
+                RocqNative.OrientSignFiltered(0, 0, 1, 0, 0, 1),
+                Is.EqualTo(RocqOrientSign.Pos));
+        }
+
+        [Test]
+        public void InCircleOutside()
+        {
+            if (!RocqNative.IsAvailable)
+            {
+                Assert.Pass("libntsrocq not loaded");
+                return;
+            }
+
+            double det = RocqNative.InCircle(0, 0, 2, 0, 1, 1, 1, -0.5);
+            Assert.That(det, Is.LessThan(0));
+        }
+    }
+}

--- a/test/NetTopologySuite.Tests.NUnit/Algorithm/RocqRef/RocqRefRunner.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Algorithm/RocqRef/RocqRefRunner.cs
@@ -1,0 +1,280 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Numerics;
+using NetTopologySuite.Algorithm;
+using NetTopologySuite.Geometries;
+
+namespace NetTopologySuite.Tests.NUnit.Algorithm.RocqRef
+{
+    /// <summary>
+    /// C# port of JTS <c>RocqRefRunner</c> (the integer-domain orientation
+    /// reference). Catalyst for NTS: prove this port equals the Java
+    /// reconstruction and the Coq <c>rocqref_refSign</c> formula.
+    /// </summary>
+    /// <remarks>
+    /// Call this RocqRefRunner, not "oracle". Production
+    /// <see cref="Orientation.Index"/> is not this class.
+    /// SoT: <c>grootstebozewolf/NetTopologySuite.Proofs</c>
+    /// <c>theories/RocqRefRunner.v</c> and
+    /// <c>docs/rocqref-jts-nts-equiv.md</c>.
+    /// </remarks>
+    public static class RocqRefRunner
+    {
+        /// <summary>Largest |coord| for which <see cref="RefSign"/> is exact in 64-bit arithmetic: 2^25.</summary>
+        public const long SafeBound = 1L << 25;
+
+        public sealed class RefCase
+        {
+            public readonly long P0x, P0y, P1x, P1y, Qx, Qy;
+            public readonly int Expected;
+
+            public RefCase(long p0x, long p0y, long p1x, long p1y, long qx, long qy)
+                : this(p0x, p0y, p1x, p1y, qx, qy, RefSign(p0x, p0y, p1x, p1y, qx, qy))
+            {
+            }
+
+            public RefCase(long p0x, long p0y, long p1x, long p1y, long qx, long qy, int expected)
+            {
+                P0x = p0x; P0y = p0y;
+                P1x = p1x; P1y = p1y;
+                Qx = qx; Qy = qy;
+                Expected = expected;
+            }
+
+            public override string ToString()
+            {
+                return "(" + P0x + " " + P0y + ", " + P1x + " " + P1y + ", " + Qx + " " + Qy
+                    + ") expected=" + Expected;
+            }
+        }
+
+        public sealed class Result
+        {
+            public long Checked;
+            public long Mismatches;
+            public readonly List<string> Failures = new List<string>();
+            private const int MaxFailuresRecorded = 20;
+
+            internal void Record(RefCase c, int actual)
+            {
+                Mismatches++;
+                if (Failures.Count < MaxFailuresRecorded)
+                    Failures.Add(c + " but Orientation.Index returned " + actual);
+            }
+
+            public bool IsSound => Mismatches == 0;
+
+            public override string ToString()
+            {
+                var sb = new System.Text.StringBuilder();
+                sb.Append(Checked).Append(" cases checked, ").Append(Mismatches).Append(" mismatch(es)");
+                foreach (var f in Failures)
+                    sb.Append("\n  ").Append(f);
+                return sb.ToString();
+            }
+        }
+
+        /// <summary>
+        /// Exact orientation sign for integer coordinates in <see cref="SafeBound"/>.
+        /// Same formula as JTS <c>RocqRefRunner.refSign</c> and Coq <c>rocqref_refSign</c>.
+        /// </summary>
+        public static int RefSign(long p0x, long p0y, long p1x, long p1y, long qx, long qy)
+        {
+            RequireInDomain(p0x); RequireInDomain(p0y);
+            RequireInDomain(p1x); RequireInDomain(p1y);
+            RequireInDomain(qx); RequireInDomain(qy);
+
+            long dx1 = p1x - p0x;
+            long dy1 = p1y - p0y;
+            long dx2 = qx - p0x;
+            long dy2 = qy - p0y;
+            long det = dx1 * dy2 - dy1 * dx2;
+            return Math.Sign(det);
+        }
+
+        /// <summary>Unconditionally exact integer determinant via <see cref="BigInteger"/>.</summary>
+        public static int RefSignBig(long p0x, long p0y, long p1x, long p1y, long qx, long qy)
+        {
+            var dx1 = new BigInteger(p1x - p0x);
+            var dy1 = new BigInteger(p1y - p0y);
+            var dx2 = new BigInteger(qx - p0x);
+            var dy2 = new BigInteger(qy - p0y);
+            return (dx1 * dy2 - dy1 * dx2).Sign;
+        }
+
+        /// <summary>
+        /// Exact orientation of arbitrary finite doubles via the common-exponent
+        /// integer determinant (Coq <c>b64_orient2d_exact</c>).
+        /// </summary>
+        public static int RefSignExact(double p0x, double p0y, double p1x, double p1y, double qx, double qy)
+        {
+            RequireFinite(p0x); RequireFinite(p0y);
+            RequireFinite(p1x); RequireFinite(p1y);
+            RequireFinite(qx); RequireFinite(qy);
+
+            Decompose(p0x, out var m0x, out var e0x);
+            Decompose(p0y, out var m0y, out var e0y);
+            Decompose(p1x, out var m1x, out var e1x);
+            Decompose(p1y, out var m1y, out var e1y);
+            Decompose(qx, out var mqx, out var eqx);
+            Decompose(qy, out var mqy, out var eqy);
+
+            int e = e0x;
+            if (e0y < e) e = e0y;
+            if (e1x < e) e = e1x;
+            if (e1y < e) e = e1y;
+            if (eqx < e) e = eqx;
+            if (eqy < e) e = eqy;
+
+            var x0 = Shift(m0x, e0x - e);
+            var y0 = Shift(m0y, e0y - e);
+            var x1 = Shift(m1x, e1x - e);
+            var y1 = Shift(m1y, e1y - e);
+            var xq = Shift(mqx, eqx - e);
+            var yq = Shift(mqy, eqy - e);
+            return ((x1 - x0) * (yq - y0) - (xq - x0) * (y1 - y0)).Sign;
+        }
+
+        public static Result Run(IEnumerable<RefCase> cases)
+        {
+            var r = new Result();
+            foreach (var c in cases)
+            {
+                r.Checked++;
+                int actual = (int)Orientation.Index(
+                    new Coordinate(c.P0x, c.P0y),
+                    new Coordinate(c.P1x, c.P1y),
+                    new Coordinate(c.Qx, c.Qy));
+                if (actual != c.Expected)
+                    r.Record(c, actual);
+            }
+            return r;
+        }
+
+        public static List<RefCase> ExhaustiveGrid(int radius)
+        {
+            var cases = new List<RefCase>();
+            for (long ax = -radius; ax <= radius; ax++)
+                for (long ay = -radius; ay <= radius; ay++)
+                    for (long bx = -radius; bx <= radius; bx++)
+                        for (long by = -radius; by <= radius; by++)
+                            for (long cx = -radius; cx <= radius; cx++)
+                                for (long cy = -radius; cy <= radius; cy++)
+                                    cases.Add(new RefCase(ax, ay, bx, by, cx, cy));
+            return cases;
+        }
+
+        public static List<RefCase> Random(int n, long bound, int seed)
+        {
+            var rnd = new Random(seed);
+            var cases = new List<RefCase>(n);
+            for (int i = 0; i < n; i++)
+            {
+                cases.Add(new RefCase(
+                    RandCoord(rnd, bound), RandCoord(rnd, bound),
+                    RandCoord(rnd, bound), RandCoord(rnd, bound),
+                    RandCoord(rnd, bound), RandCoord(rnd, bound)));
+            }
+            return cases;
+        }
+
+        public static List<RefCase> LoadProofCases(TextReader reader)
+        {
+            var cases = new List<RefCase>();
+            int lineNo = 0;
+            string line;
+            while ((line = reader.ReadLine()) != null)
+            {
+                lineNo++;
+                int hash = line.IndexOf('#');
+                if (hash >= 0)
+                    line = line.Substring(0, hash);
+                line = line.Trim();
+                if (line.Length == 0)
+                    continue;
+                var tok = line.Split((char[])null, StringSplitOptions.RemoveEmptyEntries);
+                if (tok.Length != 6 && tok.Length != 7)
+                    throw new InvalidDataException("line " + lineNo + ": expected 6 or 7 integers, got " + tok.Length);
+                long p0x = long.Parse(tok[0], CultureInfo.InvariantCulture);
+                long p0y = long.Parse(tok[1], CultureInfo.InvariantCulture);
+                long p1x = long.Parse(tok[2], CultureInfo.InvariantCulture);
+                long p1y = long.Parse(tok[3], CultureInfo.InvariantCulture);
+                long qx = long.Parse(tok[4], CultureInfo.InvariantCulture);
+                long qy = long.Parse(tok[5], CultureInfo.InvariantCulture);
+                int derived = RefSign(p0x, p0y, p1x, p1y, qx, qy);
+                if (tok.Length == 7)
+                {
+                    int claimed = int.Parse(tok[6], CultureInfo.InvariantCulture);
+                    if (claimed != derived)
+                    {
+                        throw new InvalidDataException("line " + lineNo
+                            + ": exported sign " + claimed + " disagrees with RocqRefRunner.RefSign " + derived);
+                    }
+                }
+                cases.Add(new RefCase(p0x, p0y, p1x, p1y, qx, qy, derived));
+            }
+            return cases;
+        }
+
+        private static void RequireInDomain(long c)
+        {
+            if (c < -SafeBound || c > SafeBound)
+                throw new ArgumentOutOfRangeException(nameof(c), c, "outside certified domain [-2^25, 2^25]");
+        }
+
+        private static void RequireFinite(double c)
+        {
+            if (double.IsNaN(c) || double.IsInfinity(c))
+                throw new ArgumentException("coordinate is not finite: " + c);
+        }
+
+        private static long RandCoord(Random rnd, long bound)
+        {
+            long span = 2 * bound + 1;
+            long v = FloorMod(NextLong(rnd), span) - bound;
+            return v;
+        }
+
+        private static long NextLong(Random rnd)
+        {
+            Span<byte> buf = stackalloc byte[8];
+            rnd.NextBytes(buf);
+            return BitConverter.ToInt64(buf);
+        }
+
+        private static long FloorMod(long x, long m)
+        {
+            long r = x % m;
+            return r < 0 ? r + m : r;
+        }
+
+        private static void Decompose(double d, out BigInteger mant, out int exp)
+        {
+            long bits = BitConverter.DoubleToInt64Bits(d);
+            bool neg = bits < 0;
+            int biased = (int)((bits >> 52) & 0x7FFL);
+            long frac = bits & 0xFFFFFFFFFFFFFL;
+            if (biased == 0)
+            {
+                mant = frac;
+                exp = -1074;
+            }
+            else
+            {
+                mant = frac | (1L << 52);
+                exp = biased - 1075;
+            }
+            if (neg)
+                mant = -mant;
+        }
+
+        private static BigInteger Shift(BigInteger mant, int expDelta)
+        {
+            if (expDelta < 0)
+                throw new InvalidOperationException("common exponent is not a minimum");
+            return mant << expDelta;
+        }
+    }
+}

--- a/test/NetTopologySuite.Tests.NUnit/Algorithm/RocqRef/RocqRefRunnerTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Algorithm/RocqRef/RocqRefRunnerTest.cs
@@ -1,0 +1,101 @@
+using System.IO;
+using NUnit.Framework;
+
+namespace NetTopologySuite.Tests.NUnit.Algorithm.RocqRef
+{
+    /// <summary>
+    /// NTS port of JTS <c>RocqRefRunnerTest</c>. Pins C# <see cref="RocqRefRunner.RefSign"/>
+    /// to the Coq formula and to production <c>Orientation.Index</c> on the
+    /// integer SAFE_BOUND domain. Shared vectors live in Proofs
+    /// <c>oracle/rocqref/jts_nts_equiv_vectors.txt</c>.
+    /// </summary>
+    [TestFixture]
+    public class RocqRefRunnerTest
+    {
+        [Test]
+        public void TestReferenceIsExactInDomain()
+        {
+            var rnd = new System.Random(1);
+            long bound = RocqRefRunner.SafeBound;
+            for (int i = 0; i < 50000; i++)
+            {
+                long p0x = RndIn(rnd, bound), p0y = RndIn(rnd, bound);
+                long p1x = RndIn(rnd, bound), p1y = RndIn(rnd, bound);
+                long qx = RndIn(rnd, bound), qy = RndIn(rnd, bound);
+                Assert.That(
+                    RocqRefRunner.RefSign(p0x, p0y, p1x, p1y, qx, qy),
+                    Is.EqualTo(RocqRefRunner.RefSignBig(p0x, p0y, p1x, p1y, qx, qy)));
+            }
+        }
+
+        [Test]
+        public void TestExhaustiveSmallGrid()
+        {
+            var r = RocqRefRunner.Run(RocqRefRunner.ExhaustiveGrid(4));
+            Assert.That(r.IsSound, Is.True, "orientation unsound on small grid:\n" + r);
+        }
+
+        [Test]
+        public void TestRandomWithinDomain()
+        {
+            var r = RocqRefRunner.Run(RocqRefRunner.Random(50000, RocqRefRunner.SafeBound, 42));
+            Assert.That(r.IsSound, Is.True, "orientation unsound on random sample:\n" + r);
+        }
+
+        [Test]
+        public void TestJtsNtsEquivVectors()
+        {
+            string path = Path.Combine(TestContext.CurrentContext.TestDirectory,
+                "Algorithm", "RocqRef", "jts_nts_equiv_vectors.txt");
+            Assert.That(File.Exists(path), Is.True, "missing shared vectors at " + path);
+            using (var reader = File.OpenText(path))
+            {
+                var cases = RocqRefRunner.LoadProofCases(reader);
+                Assert.That(cases.Count, Is.GreaterThan(0));
+                var r = RocqRefRunner.Run(cases);
+                Assert.That(r.IsSound, Is.True, "NTS disagrees with RocqRefRunner vectors:\n" + r);
+            }
+        }
+
+        [Test]
+        public void TestLockedUnitExamples()
+        {
+            Assert.That(RocqRefRunner.RefSign(0, 0, 1, 0, 0, 1), Is.EqualTo(1));
+            Assert.That(RocqRefRunner.RefSign(0, 0, 1, 0, 0, -1), Is.EqualTo(-1));
+            Assert.That(RocqRefRunner.RefSign(0, 0, 2, 2, 1, 1), Is.EqualTo(0));
+        }
+
+        [Test]
+        public void TestR2LiteratureHardCases()
+        {
+            double[][] triples =
+            {
+                new[] { 1.4540766091864998, -7.989685402102996,
+                    23.131039116367354, -7.004368924503866,
+                    1.4540766091865, -7.989685402102996 },
+                new[] { 219.3649559090992, 140.84159161824724,
+                    168.9018919682399, -5.713787599646864,
+                    186.80814046338352, 46.28973405831556 },
+            };
+            foreach (var t in triples)
+            {
+                int expected = RocqRefRunner.RefSignExact(t[0], t[1], t[2], t[3], t[4], t[5]);
+                int actual = (int)NetTopologySuite.Algorithm.Orientation.Index(
+                    new NetTopologySuite.Geometries.Coordinate(t[0], t[1]),
+                    new NetTopologySuite.Geometries.Coordinate(t[2], t[3]),
+                    new NetTopologySuite.Geometries.Coordinate(t[4], t[5]));
+                Assert.That(actual, Is.EqualTo(expected),
+                    "DD vs RefSignExact on literature case");
+            }
+        }
+
+        private static long RndIn(System.Random rnd, long bound)
+        {
+            long span = 2 * bound + 1;
+            long v = rnd.NextInt64();
+            long r = v % span;
+            if (r < 0) r += span;
+            return r - bound;
+        }
+    }
+}

--- a/test/NetTopologySuite.Tests.NUnit/Algorithm/RocqRef/jts_nts_equiv_vectors.txt
+++ b/test/NetTopologySuite.Tests.NUnit/Algorithm/RocqRef/jts_nts_equiv_vectors.txt
@@ -1,0 +1,35 @@
+# Shared RocqRefRunner JTS ↔ NTS equivalence vectors.
+# Provenance: theories/RocqRefRunner.v
+#   rocqref_refSign_eq_cross
+#   rocqref_idet_fits_int64
+#
+# Format (whitespace-separated; '#' comments and blank lines ignored):
+#   p0x p0y  p1x p1y  qx qy  expected
+# expected in {-1, 0, 1}: -1 = CW, 0 = collinear, +1 = CCW.
+# Every coordinate is an integer in [-2^25, 2^25] (RocqRefRunner.SAFE_BOUND).
+# The expected sign is Z.sgn of the integer 2x2 determinant — the algorithm
+# both language ports implement. Production Orientation.index is NOT the
+# reference; these rows pin the ports to each other and to the Qed formula.
+
+# --- unit turns (locked Examples in RocqRefRunner.v) ---
+0 0    1 0    0 1     1
+0 0    1 0    0 -1   -1
+0 0    2 2    1 1     0
+
+# --- basic / JTS RocqRefRunnerTest resource ---
+0 0    0 1    1 0    -1
+0 0    4 2    2 1     0
+-33554432 -33554432   33554432 33554432   0 0   0
+
+# --- near-collinear (one unit off a long diagonal) ---
+0 0    1000000 1000000   1000001 1000000   -1
+0 0    1000000 1000000   1000000 1000001    1
+
+# --- domain boundary (largest representable determinants) ---
+33554432 33554432    -33554432 -33554432    33554432 -33554432    1
+-33554432 33554432    33554432 -33554432    33554431 -33554432   -1
+
+# --- coincident / zero-length ---
+0 0    0 0    1 1     0
+5 5    5 5    5 5     0
+3 4    3 4    0 0     0

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/CircularStringTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/CircularStringTest.cs
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// AI-drafted, human-reviewed.  Assisted-by: Claude (Opus-4.7)
+
+using System;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.Geometries.Curves;
+using NUnit.Framework;
+
+namespace NetTopologySuite.Tests.NUnit.Geometries.Curves
+{
+    public class CircularStringTest
+    {
+        private readonly GeometryFactory _factory = new GeometryFactory();
+
+        private CircularString Make(params (double x, double y)[] pts)
+        {
+            var coords = new Coordinate[pts.Length];
+            for (int i = 0; i < pts.Length; i++) coords[i] = new Coordinate(pts[i].x, pts[i].y);
+            var seq = _factory.CoordinateSequenceFactory.Create(coords);
+            return new CircularString(seq, _factory);
+        }
+
+        [Test]
+        public void EmptyCircularStringHasZeroPoints()
+        {
+            var cs = new CircularString(_factory.CoordinateSequenceFactory.Create(0, Ordinates.XY), _factory);
+            Assert.That(cs.IsEmpty, Is.True);
+            Assert.That(cs.NumPoints, Is.EqualTo(0));
+            Assert.That(cs.NumArcs, Is.EqualTo(0));
+            Assert.That(cs.IsClosed, Is.False);
+        }
+
+        [Test]
+        public void SingleArcHasThreePoints()
+        {
+            var cs = Make((1, 0), (0, 1), (-1, 0));
+            Assert.That(cs.NumPoints, Is.EqualTo(3));
+            Assert.That(cs.NumArcs, Is.EqualTo(1));
+            Assert.That(cs.IsEmpty, Is.False);
+            Assert.That(cs.GeometryType, Is.EqualTo("CircularString"));
+            Assert.That(cs.OgcGeometryType, Is.EqualTo(OgcGeometryType.CircularString));
+        }
+
+        [Test]
+        public void TwoArcsHaveFivePoints()
+        {
+            var cs = Make((1, 0), (0, 1), (-1, 0), (0, -1), (1, 0));
+            Assert.That(cs.NumPoints, Is.EqualTo(5));
+            Assert.That(cs.NumArcs, Is.EqualTo(2));
+            // The endpoint equals the startpoint, so it's closed.
+            Assert.That(cs.IsClosed, Is.True);
+        }
+
+        [Test]
+        public void NonEmptyMustHaveAtLeastThreePoints()
+        {
+            var seq = _factory.CoordinateSequenceFactory.Create(new[] {
+                new Coordinate(0, 0), new Coordinate(1, 1)
+            });
+            Assert.Throws<ArgumentException>(() => new CircularString(seq, _factory));
+        }
+
+        [Test]
+        public void PointCountMustBeOdd()
+        {
+            var seq = _factory.CoordinateSequenceFactory.Create(new[] {
+                new Coordinate(0, 0), new Coordinate(1, 1),
+                new Coordinate(2, 0), new Coordinate(3, 1)
+            });
+            Assert.Throws<ArgumentException>(() => new CircularString(seq, _factory));
+        }
+
+        [Test]
+        public void StartAndEndPointsAreFirstAndLast()
+        {
+            var cs = Make((1, 2), (3, 4), (5, 6));
+            Assert.That(cs.StartPoint.X, Is.EqualTo(1));
+            Assert.That(cs.StartPoint.Y, Is.EqualTo(2));
+            Assert.That(cs.EndPoint.X, Is.EqualTo(5));
+            Assert.That(cs.EndPoint.Y, Is.EqualTo(6));
+        }
+
+        [Test]
+        public void EnvelopeEnclosesAllControlPoints()
+        {
+            var cs = Make((0, 0), (5, 10), (10, 0));
+            var env = cs.EnvelopeInternal;
+            Assert.That(env.MinX, Is.EqualTo(0));
+            Assert.That(env.MaxX, Is.EqualTo(10));
+            Assert.That(env.MinY, Is.EqualTo(0));
+            Assert.That(env.MaxY, Is.EqualTo(10));
+        }
+
+        [Test]
+        public void CopyProducesEqualButDistinctObject()
+        {
+            var cs = Make((1, 0), (0, 1), (-1, 0));
+            var copy = (CircularString)cs.Copy();
+            Assert.That(copy.EqualsExact(cs), Is.True);
+            Assert.That(ReferenceEquals(copy, cs), Is.False);
+        }
+
+        [Test]
+        public void ReverseFlipsCoordinateOrder()
+        {
+            var cs = Make((1, 0), (0, 1), (-1, 0));
+            var rev = (CircularString)cs.Reverse();
+            Assert.That(rev.StartPoint.X, Is.EqualTo(-1));
+            Assert.That(rev.EndPoint.X, Is.EqualTo(1));
+            // Double reverse is identity.
+            var revrev = (CircularString)rev.Reverse();
+            Assert.That(revrev.EqualsExact(cs), Is.True);
+        }
+
+        [Test]
+        public void EqualsExactDistinguishesCircularStringFromLineString()
+        {
+            var cs = Make((1, 0), (0, 1), (-1, 0));
+            var ls = _factory.CreateLineString(cs.Coordinates);
+            Assert.That(cs.EqualsExact(ls), Is.False,
+                "CircularString and LineString with the same coordinates should not be EqualsExact.");
+        }
+
+        [Test]
+        public void EmptyStartAndEndPointsAreNullLikeLineString()
+        {
+            var cs = new CircularString(_factory.CoordinateSequenceFactory.Create(0, Ordinates.XY), _factory);
+            Assert.That(cs.StartPoint, Is.Null);
+            Assert.That(cs.EndPoint, Is.Null);
+        }
+
+        [Test]
+        public void OpenBoundaryIsEndpoints()
+        {
+            var cs = Make((1, 0), (0, 1), (-1, 0));
+            var boundary = cs.Boundary;
+            Assert.That(boundary.NumGeometries, Is.EqualTo(2));
+            Assert.That(boundary.GetGeometryN(0).Coordinate, Is.EqualTo(new Coordinate(1, 0)));
+            Assert.That(boundary.GetGeometryN(1).Coordinate, Is.EqualTo(new Coordinate(-1, 0)));
+        }
+
+        [Test]
+        public void ClosedBoundaryIsEmpty()
+        {
+            var cs = Make((1, 0), (0, 1), (-1, 0), (0, -1), (1, 0));
+            Assert.That(cs.IsClosed, Is.True);
+            Assert.That(cs.Boundary.IsEmpty, Is.True);
+        }
+
+        [Test]
+        public void EmptyBoundaryIsEmpty()
+        {
+            var cs = new CircularString(_factory.CoordinateSequenceFactory.Create(0, Ordinates.XY), _factory);
+            Assert.That(cs.Boundary.IsEmpty, Is.True);
+        }
+
+        [Test]
+        public void IsSimpleAndIsRingDoNotThrow()
+        {
+            var open = Make((1, 0), (0, 1), (-1, 0));
+            Assert.That(() => open.IsSimple, Throws.Nothing);
+            Assert.That(() => open.IsRing, Throws.Nothing);
+            Assert.That(open.IsSimple, Is.True);
+            Assert.That(open.IsRing, Is.False);
+
+            var closed = Make((1, 0), (0, 1), (-1, 0), (0, -1), (1, 0));
+            Assert.That(() => closed.IsSimple, Throws.Nothing);
+            Assert.That(() => closed.IsRing, Throws.Nothing);
+            Assert.That(closed.IsSimple, Is.True);
+            Assert.That(closed.IsRing, Is.True);
+        }
+
+        [Test]
+        public void LinearizeReturnsLineStringThroughControlPoints()
+        {
+            var cs = Make((1, 0), (0, 1), (-1, 0));
+            ILinearizable<LineString> linearizable = cs;
+            var line = linearizable.Linearize();
+
+            Assert.That(line, Is.InstanceOf<LineString>());
+            Assert.That(line, Is.Not.InstanceOf<CircularString>());
+            Assert.That(line.NumPoints, Is.EqualTo(3));
+            Assert.That(line.Coordinates, Is.EqualTo(cs.Coordinates));
+            Assert.That(cs.Linearize(1.0).NumPoints, Is.EqualTo(3));
+        }
+
+        [Test]
+        public void LinearizeEmptyReturnsEmptyLineString()
+        {
+            var cs = new CircularString(_factory.CoordinateSequenceFactory.Create(0, Ordinates.XY), _factory);
+            Assert.That(cs.Linearize().IsEmpty, Is.True);
+        }
+    }
+}

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/CompoundCurveTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/CompoundCurveTest.cs
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// AI-drafted, human-reviewed.  Assisted-by: Claude (Fable 5)
+
+using System;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.Geometries.Curves;
+using NUnit.Framework;
+
+namespace NetTopologySuite.Tests.NUnit.Geometries.Curves
+{
+    public class CompoundCurveTest
+    {
+        private readonly GeometryFactory _factory = new GeometryFactory();
+
+        private CircularString Arc(params (double x, double y)[] pts)
+        {
+            var coords = new Coordinate[pts.Length];
+            for (int i = 0; i < pts.Length; i++) coords[i] = new Coordinate(pts[i].x, pts[i].y);
+            return new CircularString(_factory.CoordinateSequenceFactory.Create(coords), _factory);
+        }
+
+        private LineString Line(params (double x, double y)[] pts)
+        {
+            var coords = new Coordinate[pts.Length];
+            for (int i = 0; i < pts.Length; i++) coords[i] = new Coordinate(pts[i].x, pts[i].y);
+            return _factory.CreateLineString(coords);
+        }
+
+        [Test]
+        public void EmptyCompoundCurveHasZeroPoints()
+        {
+            var cc = new CompoundCurve(null, _factory);
+            Assert.That(cc.IsEmpty, Is.True);
+            Assert.That(cc.NumPoints, Is.EqualTo(0));
+            Assert.That(cc.Curves.Count, Is.EqualTo(0));
+            Assert.That(cc.IsClosed, Is.False);
+            Assert.That(cc.GeometryType, Is.EqualTo("CompoundCurve"));
+            Assert.That(cc.OgcGeometryType, Is.EqualTo(OgcGeometryType.CompoundCurve));
+        }
+
+        [Test]
+        public void LineArcLineSharesJoinPoints()
+        {
+            var cc = new CompoundCurve(
+                new Curve[] { Line((0, 0), (1, 0)), Arc((1, 0), (2, 1), (3, 0)), Line((3, 0), (4, 0)) },
+                _factory);
+
+            Assert.That(cc.Curves.Count, Is.EqualTo(3));
+            // 2 + 3 + 2 control points, with the two join points emitted once.
+            Assert.That(cc.NumPoints, Is.EqualTo(5));
+            Assert.That(cc.Coordinates.Length, Is.EqualTo(5));
+            Assert.That(cc.StartPoint.Coordinate, Is.EqualTo(new Coordinate(0, 0)));
+            Assert.That(cc.EndPoint.Coordinate, Is.EqualTo(new Coordinate(4, 0)));
+            Assert.That(cc.IsClosed, Is.False);
+        }
+
+        [Test]
+        public void MembersRetainSubtypes()
+        {
+            var cc = new CompoundCurve(
+                new Curve[] { Arc((0, 0), (1, 1), (2, 0)), Line((2, 0), (3, 0)) },
+                _factory);
+
+            Assert.That(cc.Curves[0], Is.InstanceOf<CircularString>());
+            Assert.That(cc.Curves[1], Is.InstanceOf<LineString>());
+        }
+
+        [Test]
+        public void ClosedCompoundCurveIsClosedAndHasEmptyBoundary()
+        {
+            var cc = new CompoundCurve(
+                new Curve[] { Arc((0, 0), (1, 1), (2, 0)), Line((2, 0), (0, 0)) },
+                _factory);
+
+            Assert.That(cc.IsClosed, Is.True);
+            Assert.That(cc.Boundary.IsEmpty, Is.True);
+        }
+
+        [Test]
+        public void OpenCompoundCurveBoundaryIsEndpoints()
+        {
+            var cc = new CompoundCurve(
+                new Curve[] { Line((0, 0), (1, 0)), Arc((1, 0), (2, 1), (3, 0)) },
+                _factory);
+
+            var boundary = cc.Boundary;
+            Assert.That(boundary.NumGeometries, Is.EqualTo(2));
+            Assert.That(boundary.GetGeometryN(0).Coordinate, Is.EqualTo(new Coordinate(0, 0)));
+            Assert.That(boundary.GetGeometryN(1).Coordinate, Is.EqualTo(new Coordinate(3, 0)));
+        }
+
+        [Test]
+        public void LengthIsSumOfComponentLengths()
+        {
+            var line = Line((0, 0), (1, 0));
+            var arc = Arc((1, 0), (2, 1), (3, 0));
+            var cc = new CompoundCurve(new Curve[] { line, arc }, _factory);
+
+            Assert.That(cc.Length, Is.EqualTo(line.Length + arc.Length).Within(1e-12));
+        }
+
+        [Test]
+        public void EnvelopeIsUnionOfComponentEnvelopes()
+        {
+            var cc = new CompoundCurve(
+                new Curve[] { Line((0, 0), (1, 0)), Arc((1, 0), (2, 5), (3, 0)) },
+                _factory);
+
+            var env = cc.EnvelopeInternal;
+            Assert.That(env.MinX, Is.EqualTo(0));
+            Assert.That(env.MaxX, Is.EqualTo(3));
+            Assert.That(env.MinY, Is.EqualTo(0));
+            Assert.That(env.MaxY, Is.EqualTo(5));
+        }
+
+        [Test]
+        public void RejectsNullComponents()
+        {
+            Assert.Throws<ArgumentException>(() =>
+                new CompoundCurve(new Curve[] { null }, _factory));
+        }
+
+        [Test]
+        public void RejectsEmptyComponents()
+        {
+            Assert.Throws<ArgumentException>(() =>
+                new CompoundCurve(new Curve[] { _factory.CreateLineString() }, _factory));
+        }
+
+        [Test]
+        public void RejectsNonContiguousComponents()
+        {
+            Assert.Throws<ArgumentException>(() =>
+                new CompoundCurve(
+                    new Curve[] { Line((0, 0), (1, 0)), Line((2, 0), (3, 0)) },
+                    _factory));
+        }
+
+        [Test]
+        public void RejectsNestedCompoundCurves()
+        {
+            var inner = new CompoundCurve(new Curve[] { Line((0, 0), (1, 0)) }, _factory);
+            Assert.Throws<ArgumentException>(() =>
+                new CompoundCurve(new Curve[] { inner }, _factory));
+        }
+
+        [Test]
+        public void EmptyStartAndEndPointsAreNullLikeLineString()
+        {
+            var cc = new CompoundCurve(null, _factory);
+            Assert.That(cc.StartPoint, Is.Null);
+            Assert.That(cc.EndPoint, Is.Null);
+        }
+
+        [Test]
+        public void NormalizeDoesNotMutateCallerComponentArray()
+        {
+            var components = new Curve[]
+            {
+                Line((4, 0), (3, 0)),
+                Arc((3, 0), (2, 1), (1, 0))
+            };
+            var originalFirstStart = components[0].StartPoint.Coordinate.Copy();
+
+            var cc = new CompoundCurve(components, _factory);
+            cc.Normalize();
+
+            Assert.That(components[0].StartPoint.Coordinate, Is.EqualTo(originalFirstStart),
+                "Normalize must not reverse the caller's component array in place.");
+            Assert.That(cc.StartPoint.Coordinate.CompareTo(cc.EndPoint.Coordinate) <= 0);
+        }
+
+        [Test]
+        public void IsSimpleAndIsRingDoNotThrow()
+        {
+            var open = new CompoundCurve(
+                new Curve[] { Line((0, 0), (1, 0)), Arc((1, 0), (2, 1), (3, 0)) },
+                _factory);
+            Assert.That(() => open.IsSimple, Throws.Nothing);
+            Assert.That(() => open.IsRing, Throws.Nothing);
+            Assert.That(open.IsRing, Is.False);
+
+            var closed = new CompoundCurve(
+                new Curve[] { Arc((0, 0), (1, 1), (2, 0)), Line((2, 0), (0, 0)) },
+                _factory);
+            Assert.That(() => closed.IsSimple, Throws.Nothing);
+            Assert.That(() => closed.IsRing, Throws.Nothing);
+            Assert.That(closed.IsClosed, Is.True);
+        }
+
+        [Test]
+        public void CopyProducesEqualButDistinctObjectAndPreservesSubtypes()
+        {
+            var cc = new CompoundCurve(
+                new Curve[] { Arc((0, 0), (1, 1), (2, 0)), Line((2, 0), (3, 0)) },
+                _factory);
+            var copy = (CompoundCurve)cc.Copy();
+
+            Assert.That(copy.EqualsExact(cc), Is.True);
+            Assert.That(ReferenceEquals(copy, cc), Is.False);
+            Assert.That(copy.Curves[0], Is.InstanceOf<CircularString>());
+            Assert.That(ReferenceEquals(copy.Curves[0], cc.Curves[0]), Is.False);
+        }
+
+        [Test]
+        public void ReverseFlipsComponentOrderAndDirection()
+        {
+            var cc = new CompoundCurve(
+                new Curve[] { Arc((0, 0), (1, 1), (2, 0)), Line((2, 0), (3, 0)) },
+                _factory);
+            var rev = (CompoundCurve)cc.Reverse();
+
+            Assert.That(rev.Curves[0], Is.InstanceOf<LineString>());
+            Assert.That(rev.Curves[1], Is.InstanceOf<CircularString>());
+            Assert.That(rev.StartPoint.Coordinate, Is.EqualTo(new Coordinate(3, 0)));
+            Assert.That(rev.EndPoint.Coordinate, Is.EqualTo(new Coordinate(0, 0)));
+
+            // Double reverse is identity.
+            var revrev = (CompoundCurve)rev.Reverse();
+            Assert.That(revrev.EqualsExact(cc), Is.True);
+        }
+
+        [Test]
+        public void EqualsExactDistinguishesCompoundCurveFromLineString()
+        {
+            var cc = new CompoundCurve(new Curve[] { Line((0, 0), (1, 0), (2, 0)) }, _factory);
+            var ls = Line((0, 0), (1, 0), (2, 0));
+            Assert.That(cc.EqualsExact(ls), Is.False,
+                "CompoundCurve and LineString with the same coordinates should not be EqualsExact.");
+        }
+
+        [Test]
+        public void LinearizeReturnsLineStringCollapsingJoinPoints()
+        {
+            var cc = new CompoundCurve(
+                new Curve[] { Line((0, 0), (1, 0)), Arc((1, 0), (2, 1), (3, 0)), Line((3, 0), (4, 0)) },
+                _factory);
+            ILinearizable<LineString> linearizable = cc;
+            var line = linearizable.Linearize();
+
+            Assert.That(line, Is.InstanceOf<LineString>());
+            Assert.That(line, Is.Not.InstanceOf<CompoundCurve>());
+            Assert.That(line.NumPoints, Is.EqualTo(5));
+            Assert.That(line.StartPoint.Coordinate, Is.EqualTo(new Coordinate(0, 0)));
+            Assert.That(line.EndPoint.Coordinate, Is.EqualTo(new Coordinate(4, 0)));
+        }
+    }
+}

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/CurveCompareToTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/CurveCompareToTest.cs
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// AI-drafted, human-reviewed.
+
+using System;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.Geometries.Curves;
+using NUnit.Framework;
+
+// The OGC Triangle geometry, not the coordinate utility class.
+using Triangle = NetTopologySuite.Geometries.Curves.Triangle;
+
+namespace NetTopologySuite.Tests.NUnit.Geometries.Curves
+{
+    /// <summary>
+    /// Mixed-type <see cref="Geometry.CompareTo(Geometry)"/> must order by
+    /// dedicated sort indices and never enter a wrong CompareToSameClass cast.
+    /// </summary>
+    public class CurveCompareToTest
+    {
+        private readonly GeometryFactory _factory = new GeometryFactory();
+
+        private CircularString Arc(params (double x, double y)[] pts)
+        {
+            var coords = new Coordinate[pts.Length];
+            for (int i = 0; i < pts.Length; i++) coords[i] = new Coordinate(pts[i].x, pts[i].y);
+            return new CircularString(_factory.CoordinateSequenceFactory.Create(coords), _factory);
+        }
+
+        private LineString Line(params (double x, double y)[] pts)
+        {
+            var coords = new Coordinate[pts.Length];
+            for (int i = 0; i < pts.Length; i++) coords[i] = new Coordinate(pts[i].x, pts[i].y);
+            return _factory.CreateLineString(coords);
+        }
+
+        private LinearRing Ring(params (double x, double y)[] pts)
+        {
+            var coords = new Coordinate[pts.Length];
+            for (int i = 0; i < pts.Length; i++) coords[i] = new Coordinate(pts[i].x, pts[i].y);
+            return _factory.CreateLinearRing(coords);
+        }
+
+        [Test]
+        public void CircularStringCompareToLineStringDoesNotThrow()
+        {
+            var circularString = Arc((0, 0), (1, 1), (2, 0));
+            var lineString = Line((0, 0), (1, 1), (2, 0));
+
+            Assert.That(() => circularString.CompareTo(lineString), Throws.Nothing);
+            Assert.That(() => lineString.CompareTo(circularString), Throws.Nothing);
+            Assert.That(circularString.CompareTo(lineString), Is.Not.EqualTo(0));
+            Assert.That(circularString.CompareTo(lineString),
+                Is.EqualTo(-lineString.CompareTo(circularString)));
+        }
+
+        [Test]
+        public void CompoundCurveCompareToLineStringDoesNotThrow()
+        {
+            var compoundCurve = new CompoundCurve(
+                new Curve[] { Line((0, 0), (1, 0)), Arc((1, 0), (2, 1), (3, 0)) },
+                _factory);
+            var lineString = Line((0, 0), (1, 0), (2, 1), (3, 0));
+
+            Assert.That(() => compoundCurve.CompareTo(lineString), Throws.Nothing);
+            Assert.That(() => lineString.CompareTo(compoundCurve), Throws.Nothing);
+            Assert.That(compoundCurve.CompareTo(lineString), Is.Not.EqualTo(0));
+        }
+
+        [Test]
+        public void CurvePolygonCompareToPolygonDoesNotThrow()
+        {
+            var shell = Ring((0, 0), (10, 0), (10, 10), (0, 10), (0, 0));
+            var curvePolygon = new CurvePolygon(shell, _factory);
+            var polygon = _factory.CreatePolygon(shell);
+
+            Assert.That(() => curvePolygon.CompareTo(polygon), Throws.Nothing);
+            Assert.That(() => polygon.CompareTo(curvePolygon), Throws.Nothing);
+            Assert.That(curvePolygon.CompareTo(polygon), Is.Not.EqualTo(0));
+            Assert.That(curvePolygon.CompareTo(polygon),
+                Is.EqualTo(-polygon.CompareTo(curvePolygon)));
+        }
+
+        [Test]
+        public void TriangleCompareToPolygonDoesNotThrow()
+        {
+            var shell = Ring((0, 0), (1, 0), (0, 1), (0, 0));
+            var triangle = new Triangle(shell, _factory);
+            var polygon = _factory.CreatePolygon(shell);
+
+            Assert.That(() => triangle.CompareTo(polygon), Throws.Nothing);
+            Assert.That(() => polygon.CompareTo(triangle), Throws.Nothing);
+            Assert.That(triangle.CompareTo(polygon), Is.Not.EqualTo(0));
+        }
+
+        [Test]
+        public void TinCompareToMultiPolygonDoesNotThrow()
+        {
+            var t1 = new Triangle(Ring((0, 0), (1, 0), (0, 1), (0, 0)), _factory);
+            var t2 = new Triangle(Ring((1, 0), (1, 1), (0, 1), (1, 0)), _factory);
+            var tin = new Tin(new[] { t1, t2 }, _factory);
+            var multiPolygon = _factory.CreateMultiPolygon(new[]
+            {
+                _factory.CreatePolygon(Ring((0, 0), (1, 0), (0, 1), (0, 0))),
+                _factory.CreatePolygon(Ring((1, 0), (1, 1), (0, 1), (1, 0)))
+            });
+
+            Assert.That(() => tin.CompareTo(multiPolygon), Throws.Nothing);
+            Assert.That(() => multiPolygon.CompareTo(tin), Throws.Nothing);
+            Assert.That(tin.CompareTo(multiPolygon), Is.Not.EqualTo(0));
+        }
+
+        [Test]
+        public void ArraySortOfMixedLinearAndCurveTypesDoesNotThrow()
+        {
+            Geometry[] geometries =
+            {
+                Line((0, 0), (1, 0)),
+                Arc((0, 0), (1, 1), (2, 0)),
+                new CompoundCurve(new Curve[] { Line((0, 0), (1, 0)), Arc((1, 0), (2, 1), (3, 0)) }, _factory),
+                _factory.CreatePolygon(Ring((0, 0), (1, 0), (1, 1), (0, 1), (0, 0))),
+                new CurvePolygon(Arc((0, 0), (2, 2), (4, 0), (2, -2), (0, 0)), _factory),
+                new Triangle(Ring((0, 0), (1, 0), (0, 1), (0, 0)), _factory)
+            };
+
+            Assert.That(() => Array.Sort(geometries), Throws.Nothing);
+
+            // Sorted order must be stable under a second pass and anti-symmetric.
+            for (int i = 0; i < geometries.Length - 1; i++)
+            {
+                Assert.That(geometries[i].CompareTo(geometries[i + 1]), Is.LessThanOrEqualTo(0));
+            }
+        }
+
+        [Test]
+        public void SameTypeCompareToUsesStructuralOrderNotOnlySortIndex()
+        {
+            var a = Arc((0, 0), (1, 1), (2, 0));
+            var b = Arc((0, 0), (1, 2), (2, 0));
+            Assert.That(a.CompareTo(b), Is.Not.EqualTo(0));
+            Assert.That(a.CompareTo(a.Copy()), Is.EqualTo(0));
+        }
+    }
+}

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/CurvePolygonTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/CurvePolygonTest.cs
@@ -1,0 +1,297 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// AI-drafted, human-reviewed.  Assisted-by: Claude (Fable 5)
+//
+// The "FCP_*" tests are the in-tree port of CurvePolygonStructuralSpec from the
+// out-of-tree NetTopologySuite.Curve repository. They pin the F-CP (Structural
+// CurvePolygon) contract of the SFA Curve Awareness epic (locationtech/jts#1195,
+// Phase 1): rings are exposed as Curve and never collapse to LinearRing on
+// access, copy, or WKT round-trip. Per NTS convention these stay in the
+// codebase indefinitely as a regression net. The out-of-tree sub-TAG FCP-TL
+// (linearization) depends on facilities this prototype does not carry yet; it
+// comes back with the linearization follow-up.
+
+using System;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.Geometries.Curves;
+using NetTopologySuite.IO;
+using NUnit.Framework;
+
+namespace NetTopologySuite.Tests.NUnit.Geometries.Curves
+{
+    [Category("CurveAwareness")]
+    public class CurvePolygonTest
+    {
+        private readonly GeometryFactory _factory = new GeometryFactory();
+
+        private CircularString Arc(params (double x, double y)[] pts)
+        {
+            var coords = new Coordinate[pts.Length];
+            for (int i = 0; i < pts.Length; i++) coords[i] = new Coordinate(pts[i].x, pts[i].y);
+            return new CircularString(_factory.CoordinateSequenceFactory.Create(coords), _factory);
+        }
+
+        private LinearRing Ring(params (double x, double y)[] pts)
+        {
+            var coords = new Coordinate[pts.Length];
+            for (int i = 0; i < pts.Length; i++) coords[i] = new Coordinate(pts[i].x, pts[i].y);
+            return _factory.CreateLinearRing(coords);
+        }
+
+        private LineString Line(params (double x, double y)[] pts)
+        {
+            var coords = new Coordinate[pts.Length];
+            for (int i = 0; i < pts.Length; i++) coords[i] = new Coordinate(pts[i].x, pts[i].y);
+            return _factory.CreateLineString(coords);
+        }
+
+        /// <summary>A compound shell made of two semi-circles, plus one linear hole.</summary>
+        private CurvePolygon CompoundShellWithLinearHole()
+        {
+            var shell = new CompoundCurve(
+                new Curve[] { Arc((0, 0), (5, 5), (10, 0)), Arc((10, 0), (5, -5), (0, 0)) },
+                _factory);
+            var hole = Ring((2, -1), (8, -1), (8, 1), (2, 1), (2, -1));
+            return new CurvePolygon(shell, new Curve[] { hole }, _factory);
+        }
+
+        /// <summary>A CurvePolygon with a CircularString hole inside a flat shell.</summary>
+        private CurvePolygon FlatShellWithArcHole()
+        {
+            var shell = Ring((0, 0), (100, 0), (100, 100), (0, 100), (0, 0));
+            var hole = Arc((40, 50), (50, 60), (60, 50), (50, 40), (40, 50));
+            return new CurvePolygon(shell, new Curve[] { hole }, _factory);
+        }
+
+        // ============================================================
+        // F-CP structural contract (ported from CurvePolygonStructuralSpec)
+        // ============================================================
+
+        [Test]
+        public void FCP_S_compound_shell_exposed_as_CompoundCurve()
+        {
+            var cp = CompoundShellWithLinearHole();
+            Assert.That(cp.ExteriorRing, Is.InstanceOf<CompoundCurve>(),
+                "FCP-S: compound shell should be exposed as CompoundCurve, got "
+                + cp.ExteriorRing.GetType().Name);
+        }
+
+        [Test]
+        public void FCP_S_arc_shell_exposed_as_CircularString()
+        {
+            var cp = new CurvePolygon(Arc((0, 0), (10, 0), (5, 5), (0, 5), (0, 0)), _factory);
+            Assert.That(cp.ExteriorRing, Is.InstanceOf<CircularString>(),
+                "FCP-S: arc shell should be exposed as CircularString, got "
+                + cp.ExteriorRing.GetType().Name);
+        }
+
+        [Test]
+        public void FCP_MEM_compound_shell_members_retain_subtypes()
+        {
+            var cp = CompoundShellWithLinearHole();
+            var cc = (CompoundCurve)cp.ExteriorRing;
+            Assert.That(cc.Curves.Count, Is.EqualTo(2),
+                "FCP-MEM: compound shell should have two members");
+            Assert.That(cc.Curves[0], Is.InstanceOf<CircularString>(),
+                "FCP-MEM: member 0 should be a CircularString");
+            Assert.That(cc.Curves[1], Is.InstanceOf<CircularString>(),
+                "FCP-MEM: member 1 should be a CircularString");
+        }
+
+        [Test]
+        public void FCP_H_arc_hole_exposed_as_CircularString()
+        {
+            var cp = FlatShellWithArcHole();
+            Assert.That(cp.NumInteriorRings, Is.EqualTo(1),
+                "FCP-H: CurvePolygon has one interior ring");
+            Assert.That(cp.GetInteriorRingN(0), Is.InstanceOf<CircularString>(),
+                "FCP-H: arc hole should be a CircularString, got "
+                + cp.GetInteriorRingN(0).GetType().Name);
+        }
+
+        [Test]
+        public void FCP_CP_copy_preserves_shell_subtype()
+        {
+            var cp = CompoundShellWithLinearHole();
+            var copy = (CurvePolygon)cp.Copy();
+
+            Assert.That(copy.ExteriorRing, Is.InstanceOf<CompoundCurve>(),
+                "FCP-CP: copied shell must also be a CompoundCurve, got "
+                + copy.ExteriorRing.GetType().Name);
+            Assert.That(copy.ExteriorRing, Is.Not.SameAs(cp.ExteriorRing),
+                "FCP-CP: copy must be a deep copy of the shell");
+            Assert.That(copy.EqualsExact(cp), Is.True);
+        }
+
+        [Test]
+        public void FCP_CP_copy_preserves_arc_hole_subtype()
+        {
+            var cp = FlatShellWithArcHole();
+            var copy = (CurvePolygon)cp.Copy();
+
+            Assert.That(copy.GetInteriorRingN(0), Is.InstanceOf<CircularString>(),
+                "FCP-CP: copied hole must remain a CircularString, got "
+                + copy.GetInteriorRingN(0).GetType().Name);
+        }
+
+        [Test]
+        public void FCP_WKT_roundtrip_preserves_compound_shell()
+        {
+            var cp = CompoundShellWithLinearHole();
+            string emitted = new WKTWriter().Write(cp);
+
+            Assert.That(emitted.ToUpperInvariant(), Does.Contain("COMPOUNDCURVE"),
+                "FCP-WKT: emitted WKT must contain the COMPOUNDCURVE tag, got: " + emitted);
+
+            var roundTripped = (CurvePolygon)new WKTReader().Read(emitted);
+            Assert.That(roundTripped.ExteriorRing, Is.InstanceOf<CompoundCurve>(),
+                "FCP-WKT: round-tripped shell must remain a CompoundCurve, got "
+                + roundTripped.ExteriorRing.GetType().Name);
+        }
+
+        [Test]
+        public void FCP_WKT_roundtrip_preserves_arc_shell()
+        {
+            var cp = new CurvePolygon(Arc((0, 0), (10, 0), (5, 5), (0, 5), (0, 0)), _factory);
+            string emitted = new WKTWriter().Write(cp);
+
+            Assert.That(emitted.ToUpperInvariant(), Does.Contain("CIRCULARSTRING"),
+                "FCP-WKT: emitted WKT must contain the CIRCULARSTRING tag, got: " + emitted);
+
+            var roundTripped = (CurvePolygon)new WKTReader().Read(emitted);
+            Assert.That(roundTripped.ExteriorRing, Is.InstanceOf<CircularString>(),
+                "FCP-WKT: round-tripped shell must remain a CircularString, got "
+                + roundTripped.ExteriorRing.GetType().Name);
+        }
+
+        [Test]
+        public void FCP_DOVE_ring_accessors_are_typed_Curve()
+        {
+            var exteriorRingType = typeof(CurvePolygon).GetProperty(nameof(CurvePolygon.ExteriorRing))?.PropertyType;
+            Assert.That(exteriorRingType, Is.Not.Null,
+                "FCP-DOVE: CurvePolygon must expose an ExteriorRing accessor");
+            Assert.That(exteriorRingType, Is.EqualTo(typeof(Curve)),
+                "FCP-DOVE: CurvePolygon.ExteriorRing must be typed as Curve "
+                + "(the polymorphic base of LinearRing / LineString / CircularString / "
+                + "CompoundCurve). If this returns LinearRing again, the JTS-side "
+                + "FCP-DOVE A/B/C dovetail decision needs to be made here too.");
+        }
+
+        // ============================================================
+        // Construction and basic behavior
+        // ============================================================
+
+        [Test]
+        public void EmptyCurvePolygonHasZeroPoints()
+        {
+            var cp = new CurvePolygon(null, _factory);
+            Assert.That(cp.IsEmpty, Is.True);
+            Assert.That(cp.NumPoints, Is.EqualTo(0));
+            Assert.That(cp.NumInteriorRings, Is.EqualTo(0));
+            Assert.That(cp.Area, Is.EqualTo(0));
+            Assert.That(cp.GeometryType, Is.EqualTo("CurvePolygon"));
+            Assert.That(cp.OgcGeometryType, Is.EqualTo(OgcGeometryType.CurvePolygon));
+        }
+
+        [Test]
+        public void RejectsUnclosedShell()
+        {
+            Assert.Throws<ArgumentException>(() =>
+                new CurvePolygon(Arc((0, 0), (1, 1), (2, 0)), _factory));
+        }
+
+        [Test]
+        public void RejectsUnclosedHole()
+        {
+            var shell = Ring((0, 0), (10, 0), (10, 10), (0, 10), (0, 0));
+            Assert.Throws<ArgumentException>(() =>
+                new CurvePolygon(shell, new Curve[] { Line((1, 1), (2, 2)) }, _factory));
+        }
+
+        [Test]
+        public void RejectsEmptyShellWithHoles()
+        {
+            var hole = Ring((2, 2), (4, 2), (4, 4), (2, 4), (2, 2));
+            Assert.Throws<ArgumentException>(() =>
+                new CurvePolygon(null, new Curve[] { hole }, _factory));
+        }
+
+        [Test]
+        public void RejectsNullHoles()
+        {
+            var shell = Ring((0, 0), (10, 0), (10, 10), (0, 10), (0, 0));
+            Assert.Throws<ArgumentException>(() =>
+                new CurvePolygon(shell, new Curve[] { null }, _factory));
+        }
+
+        [Test]
+        public void ChordBasedAreaSubtractsHoles()
+        {
+            var shell = Ring((0, 0), (10, 0), (10, 10), (0, 10), (0, 0));
+            var hole = Ring((2, 2), (4, 2), (4, 4), (2, 4), (2, 2));
+            var cp = new CurvePolygon(shell, new Curve[] { hole }, _factory);
+
+            Assert.That(cp.Area, Is.EqualTo(96).Within(1e-12));
+            Assert.That(cp.Length, Is.EqualTo(40 + 8).Within(1e-12));
+        }
+
+        [Test]
+        public void EnvelopeIsShellEnvelope()
+        {
+            var cp = CompoundShellWithLinearHole();
+            var env = cp.EnvelopeInternal;
+            Assert.That(env.MinX, Is.EqualTo(0));
+            Assert.That(env.MaxX, Is.EqualTo(10));
+            Assert.That(env.MinY, Is.EqualTo(-5));
+            Assert.That(env.MaxY, Is.EqualTo(5));
+        }
+
+        [Test]
+        public void BoundaryExposesAllRings()
+        {
+            var cp = FlatShellWithArcHole();
+            var boundary = cp.Boundary;
+            Assert.That(boundary.NumGeometries, Is.EqualTo(2));
+            Assert.That(boundary.GetGeometryN(0), Is.InstanceOf<LinearRing>());
+            Assert.That(boundary.GetGeometryN(1), Is.InstanceOf<CircularString>());
+        }
+
+        [Test]
+        public void ReversePreservesRingSubtypes()
+        {
+            var cp = CompoundShellWithLinearHole();
+            var rev = (CurvePolygon)cp.Reverse();
+
+            Assert.That(rev.ExteriorRing, Is.InstanceOf<CompoundCurve>());
+            Assert.That(rev.NumInteriorRings, Is.EqualTo(1));
+
+            // Double reverse is identity.
+            var revrev = (CurvePolygon)rev.Reverse();
+            Assert.That(revrev.EqualsExact(cp), Is.True);
+        }
+
+        [Test]
+        public void EqualsExactDistinguishesCurvePolygonFromPolygon()
+        {
+            var shellCoords = new[] { (0d, 0d), (10d, 0d), (10d, 10d), (0d, 10d), (0d, 0d) };
+            var cp = new CurvePolygon(Ring(shellCoords), _factory);
+            var polygon = _factory.CreatePolygon(Ring(shellCoords));
+            Assert.That(cp.EqualsExact(polygon), Is.False,
+                "CurvePolygon and Polygon with the same shell should not be EqualsExact.");
+        }
+
+        [Test]
+        public void LinearizeReturnsLinearPolygonWithLinearRings()
+        {
+            var cp = FlatShellWithArcHole();
+            ILinearizable<Polygon> linearizable = cp;
+            var polygon = linearizable.Linearize();
+
+            Assert.That(polygon, Is.InstanceOf<Polygon>());
+            Assert.That(polygon, Is.Not.InstanceOf<CurvePolygon>());
+            Assert.That(polygon.ExteriorRing, Is.InstanceOf<LinearRing>());
+            Assert.That(polygon.NumInteriorRings, Is.EqualTo(1));
+            Assert.That(polygon.GetInteriorRingN(0), Is.InstanceOf<LinearRing>());
+            Assert.That(polygon.GetInteriorRingN(0).NumPoints, Is.EqualTo(5));
+        }
+    }
+}

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/CurveWktTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/CurveWktTest.cs
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// AI-drafted, human-reviewed.  Assisted-by: Claude (Fable 5)
+
+using System;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.Geometries.Curves;
+using NetTopologySuite.IO;
+using NUnit.Framework;
+
+// The OGC Triangle geometry, not the coordinate utility class.
+using Triangle = NetTopologySuite.Geometries.Curves.Triangle;
+
+namespace NetTopologySuite.Tests.NUnit.Geometries.Curves
+{
+    /// <summary>
+    /// WKT round-trip tests for the curve prototype types (CIRCULARSTRING,
+    /// COMPOUNDCURVE, CURVEPOLYGON, TRIANGLE, TIN).
+    /// </summary>
+    public class CurveWktTest
+    {
+        [TestCase("CIRCULARSTRING (0 0, 1 1, 2 0)", typeof(CircularString))]
+        [TestCase("CIRCULARSTRING (0 0, 1 1, 2 0, 3 -1, 4 0)", typeof(CircularString))]
+        [TestCase("CIRCULARSTRING EMPTY", typeof(CircularString))]
+        [TestCase("COMPOUNDCURVE ((0 0, 1 0), CIRCULARSTRING (1 0, 2 1, 3 0), (3 0, 4 0))", typeof(CompoundCurve))]
+        [TestCase("COMPOUNDCURVE (CIRCULARSTRING (0 0, 1 1, 2 0), (2 0, 3 0))", typeof(CompoundCurve))]
+        [TestCase("COMPOUNDCURVE EMPTY", typeof(CompoundCurve))]
+        [TestCase("CURVEPOLYGON (CIRCULARSTRING (0 0, 2 2, 4 0, 2 -2, 0 0))", typeof(CurvePolygon))]
+        [TestCase("CURVEPOLYGON (COMPOUNDCURVE (CIRCULARSTRING (0 0, 5 5, 10 0), (10 0, 0 0)), (2 1, 8 1, 8 2, 2 2, 2 1))", typeof(CurvePolygon))]
+        [TestCase("CURVEPOLYGON ((0 0, 100 0, 100 100, 0 100, 0 0), CIRCULARSTRING (40 50, 50 60, 60 50, 50 40, 40 50))", typeof(CurvePolygon))]
+        [TestCase("CURVEPOLYGON EMPTY", typeof(CurvePolygon))]
+        [TestCase("TRIANGLE ((0 0, 1 0, 0 1, 0 0))", typeof(Triangle))]
+        [TestCase("TRIANGLE EMPTY", typeof(Triangle))]
+        [TestCase("TIN (((0 0, 1 0, 0 1, 0 0)), ((1 0, 1 1, 0 1, 1 0)))", typeof(Tin))]
+        [TestCase("TIN EMPTY", typeof(Tin))]
+        [TestCase("GEOMETRYCOLLECTION (CIRCULARSTRING (0 0, 1 1, 2 0), POINT (5 5))", typeof(GeometryCollection))]
+        public void WktRoundTripIsStable(string wkt, Type expectedType)
+        {
+            var reader = new WKTReader();
+
+            var geometry = reader.Read(wkt);
+            Assert.That(geometry, Is.InstanceOf(expectedType));
+
+            string written = geometry.AsText();
+            Assert.That(written, Is.EqualTo(wkt));
+
+            var reparsed = reader.Read(written);
+            Assert.That(reparsed.EqualsExact(geometry), Is.True,
+                "Round-tripped geometry should be EqualsExact to the original.");
+        }
+
+        [Test]
+        public void ReadPreservesComponentAndRingSubtypes()
+        {
+            var reader = new WKTReader();
+
+            var cc = (CompoundCurve)reader.Read("COMPOUNDCURVE ((0 0, 1 0), CIRCULARSTRING (1 0, 2 1, 3 0))");
+            Assert.That(cc.Curves[0], Is.InstanceOf<LineString>());
+            Assert.That(cc.Curves[1], Is.InstanceOf<CircularString>());
+
+            var cp = (CurvePolygon)reader.Read(
+                "CURVEPOLYGON ((0 0, 100 0, 100 100, 0 100, 0 0), CIRCULARSTRING (40 50, 50 60, 60 50, 50 40, 40 50))");
+            Assert.That(cp.ExteriorRing, Is.InstanceOf<LineString>());
+            Assert.That(cp.GetInteriorRingN(0), Is.InstanceOf<CircularString>());
+        }
+
+        [Test]
+        public void ReadSupportsZOrdinates()
+        {
+            var geometry = new WKTReader().Read("CIRCULARSTRING Z(0 0 5, 1 1 5, 2 0 5)");
+
+            var circularString = (CircularString)geometry;
+            Assert.That(circularString.CoordinateSequence.GetZ(0), Is.EqualTo(5));
+            Assert.That(new WKTWriter(3).Write(geometry), Is.EqualTo("CIRCULARSTRING Z(0 0 5, 1 1 5, 2 0 5)"));
+        }
+
+        [Test]
+        public void ReadRejectsNestedCompoundCurves()
+        {
+            Assert.Throws<ParseException>(() =>
+                new WKTReader().Read("COMPOUNDCURVE (COMPOUNDCURVE ((0 0, 1 0)))"));
+        }
+
+        [Test]
+        public void ReadRejectsTriangleWithInteriorRing()
+        {
+            Assert.Throws<ParseException>(() =>
+                new WKTReader().Read("TRIANGLE ((0 0, 10 0, 0 10, 0 0), (1 1, 2 1, 1 2, 1 1))"));
+        }
+
+        [Test]
+        public void ReadRejectsUnexpectedCurveComponent()
+        {
+            Assert.Throws<ParseException>(() =>
+                new WKTReader().Read("CURVEPOLYGON (POINT (0 0))"));
+        }
+
+        [Test]
+        public void ReadRejectsEvenCircularStringPointCount()
+        {
+            Assert.Throws<ArgumentException>(() =>
+                new WKTReader().Read("CIRCULARSTRING (0 0, 1 1)"));
+        }
+
+        [Test]
+        public void ReadRejectsNonContiguousCompoundCurve()
+        {
+            Assert.Throws<ArgumentException>(() =>
+                new WKTReader().Read("COMPOUNDCURVE ((0 0, 1 0), (2 0, 3 0))"));
+        }
+    }
+}

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/TriangleAndTinTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/TriangleAndTinTest.cs
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// AI-drafted, human-reviewed.  Assisted-by: Claude (Opus-4.7)
+
+using System;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.Geometries.Curves;
+using NUnit.Framework;
+using Triangle = NetTopologySuite.Geometries.Curves.Triangle;
+
+namespace NetTopologySuite.Tests.NUnit.Geometries.Curves
+{
+    public class TriangleAndTinTest
+    {
+        private readonly GeometryFactory _factory = new GeometryFactory();
+
+        private LinearRing TriRing(double ax, double ay, double bx, double by, double cx, double cy)
+        {
+            var coords = new[]
+            {
+                new Coordinate(ax, ay),
+                new Coordinate(bx, by),
+                new Coordinate(cx, cy),
+                new Coordinate(ax, ay),
+            };
+            return _factory.CreateLinearRing(coords);
+        }
+
+        [Test]
+        public void TriangleAcceptsFourCoordRing()
+        {
+            var t = new Triangle(TriRing(0, 0, 10, 0, 5, 8), _factory);
+            Assert.That(t.NumPoints, Is.EqualTo(4));
+            Assert.That(t.GeometryType, Is.EqualTo("Triangle"));
+            Assert.That(t.OgcGeometryType, Is.EqualTo(OgcGeometryType.Triangle));
+            Assert.That(t.NumInteriorRings, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void TriangleAreaIsHalfBaseTimesHeight()
+        {
+            var t = new Triangle(TriRing(0, 0, 10, 0, 0, 8), _factory);
+            Assert.That(t.Area, Is.EqualTo(40.0).Within(1e-9));
+        }
+
+        [Test]
+        public void TriangleSignedAreaIsPositiveForCCW()
+        {
+            var t = new Triangle(TriRing(0, 0, 10, 0, 5, 8), _factory);
+            Assert.That(t.SignedDoubleArea, Is.GreaterThan(0));
+        }
+
+        [Test]
+        public void TriangleSignedAreaIsNegativeForCW()
+        {
+            var t = new Triangle(TriRing(0, 0, 5, 8, 10, 0), _factory);
+            Assert.That(t.SignedDoubleArea, Is.LessThan(0));
+        }
+
+        [Test]
+        public void TriangleSignedAreaIsZeroForCollinear()
+        {
+            var t = new Triangle(TriRing(0, 0, 1, 1, 2, 2), _factory);
+            Assert.That(t.SignedDoubleArea, Is.EqualTo(0).Within(1e-9));
+            Assert.That(t.Area, Is.EqualTo(0).Within(1e-9));
+        }
+
+        [Test]
+        public void TriangleRejectsNon4PointRing()
+        {
+            var ring = _factory.CreateLinearRing(new[]
+            {
+                new Coordinate(0, 0), new Coordinate(10, 0),
+                new Coordinate(10, 10), new Coordinate(0, 10),
+                new Coordinate(0, 0)
+            });
+            Assert.Throws<ArgumentException>(() => new Triangle(ring, _factory));
+        }
+
+        [Test]
+        public void TriangleHasNoInteriorRings()
+        {
+            var t = new Triangle(TriRing(0, 0, 10, 0, 5, 8), _factory);
+            Assert.Throws<ArgumentOutOfRangeException>(() => t.GetInteriorRingN(0));
+        }
+
+        [Test]
+        public void TriangleCopyIsEqualButDistinct()
+        {
+            var t = new Triangle(TriRing(0, 0, 10, 0, 5, 8), _factory);
+            var copy = (Triangle)t.Copy();
+            Assert.That(copy.EqualsExact(t), Is.True);
+            Assert.That(ReferenceEquals(copy, t), Is.False);
+        }
+
+        [Test]
+        public void TriangleReverseFlipsVertexOrder()
+        {
+            var t = new Triangle(TriRing(0, 0, 10, 0, 5, 8), _factory);
+            var rev = (Triangle)t.Reverse();
+            Assert.That(rev.SignedDoubleArea, Is.EqualTo(-t.SignedDoubleArea).Within(1e-9));
+        }
+
+        [Test]
+        public void TinHoldsTriangles()
+        {
+            var t1 = new Triangle(TriRing(0, 0, 10, 0, 5, 8), _factory);
+            var t2 = new Triangle(TriRing(10, 0, 20, 0, 15, 8), _factory);
+            var tin = new Tin(new[] { t1, t2 }, _factory);
+            Assert.That(tin.NumGeometries, Is.EqualTo(2));
+            Assert.That(tin.GeometryType, Is.EqualTo("TIN"));
+            Assert.That(tin.OgcGeometryType, Is.EqualTo(OgcGeometryType.TIN));
+        }
+
+        [Test]
+        public void TinAreaIsSumOfTriangleAreas()
+        {
+            var t1 = new Triangle(TriRing(0, 0, 10, 0, 0, 8), _factory);
+            var t2 = new Triangle(TriRing(10, 0, 20, 0, 10, 4), _factory);
+            var tin = new Tin(new[] { t1, t2 }, _factory);
+            Assert.That(tin.Area, Is.EqualTo(40.0 + 20.0).Within(1e-9));
+        }
+
+        [Test]
+        public void EmptyTinHasZeroGeometries()
+        {
+            var tin = new Tin(new Triangle[0], _factory);
+            Assert.That(tin.NumGeometries, Is.EqualTo(0));
+            Assert.That(tin.Area, Is.EqualTo(0.0));
+        }
+
+        [Test]
+        public void TinGetTriangleNReturnsTypedElement()
+        {
+            var t1 = new Triangle(TriRing(0, 0, 10, 0, 5, 8), _factory);
+            var tin = new Tin(new[] { t1 }, _factory);
+            var got = tin.GetTriangleN(0);
+            Assert.That(got, Is.SameAs(t1));
+        }
+
+        [Test]
+        public void TinCopyDeepCopiesTriangles()
+        {
+            var t1 = new Triangle(TriRing(0, 0, 10, 0, 5, 8), _factory);
+            var tin = new Tin(new[] { t1 }, _factory);
+            var copy = (Tin)tin.Copy();
+            Assert.That(copy.NumGeometries, Is.EqualTo(1));
+            Assert.That(copy.GetTriangleN(0).EqualsExact(t1), Is.True);
+            Assert.That(ReferenceEquals(copy.GetTriangleN(0), t1), Is.False);
+        }
+    }
+}

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/GeometryCollectionImplTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/GeometryCollectionImplTest.cs
@@ -51,6 +51,30 @@ namespace NetTopologySuite.Tests.NUnit.Geometries
         }
 
         [Test]
+        public void TestDimensionEmptyElement()
+        {
+            // an empty element still contributes its dimension, matching JTS semantics
+            // (see https://github.com/locationtech/jts/pull/1103)
+            var g = Read("GEOMETRYCOLLECTION (POLYGON EMPTY, LINESTRING (1 1, 5 4), POINT (6 5))");
+            Assert.That(g.Dimension, Is.EqualTo(Dimension.Surface));
+            Assert.That(g.HasDimension(Dimension.Surface), Is.True);
+            Assert.That(g.HasDimension(Dimension.Curve), Is.True);
+            Assert.That(g.HasDimension(Dimension.Point), Is.True);
+        }
+
+        [Test]
+        public void TestDimensionNestedCollection()
+        {
+            var g = Read("GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (1 1), LINESTRING (1 1, 5 4)), POLYGON ((1 9, 5 9, 5 5, 1 5, 1 9)))");
+            Assert.That(g.Dimension, Is.EqualTo(Dimension.Surface));
+            Assert.That(g.HasDimension(Dimension.Point), Is.True);
+            Assert.That(g.HasDimension(Dimension.Curve), Is.True);
+            Assert.That(g.HasDimension(Dimension.Surface), Is.True);
+        }
+
+
+
+        [Test]
         public void TestGetCoordinates()
         {
             var g = (GeometryCollection)reader.Read("GEOMETRYCOLLECTION (POINT (10 10), POINT (30 30), LINESTRING (15 15, 20 20))");

--- a/test/NetTopologySuite.Tests.NUnit/NetTopologySuite.Tests.NUnit.csproj
+++ b/test/NetTopologySuite.Tests.NUnit/NetTopologySuite.Tests.NUnit.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <EmbeddedResource Include="TestData\*" Exclude="*.cs" />
+    <None Include="Algorithm\RocqRef\jts_nts_equiv_vectors.txt" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/NetTopologySuite.Tests.NUnit/Noding/Snapround/HotPixelTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Noding/Snapround/HotPixelTest.cs
@@ -269,19 +269,17 @@ namespace NetTopologySuite.Tests.NUnit.Noding.Snaparound
             Assert.That(actual, Is.EqualTo(expected));
         }
 
-        // Oracle-driven linear baseline hardening (Cycle 2): pin adversarial sub-ulp passes-through cases
-        // from Proofs oracle (passes_through_proof_vectors.txt). These are the machine-checked unsound
-        // rounded FILTER over-accept cases (#66). Current NTS HotPixel returns TRUE on these vectors
-        // (matches FILTER); full rejection to match EXACT is a desired future hardening.
+        // Segments that graze a unit-scale hot pixel just outside a representable
+        // 1-ulp step. Pins the current Intersects result (true).
         [Test]
-        public void TestOracleSubUlpAdversarialBR()
+        public void TestIntersectsNearPixelScaleBoundaryBR()
         {
             CheckIntersects(true, 0, -1, 1,
                 1.0, -1.0000000000002, 0.4999999999998, -1.4000000000002);
         }
 
         [Test]
-        public void TestOracleSubUlpAdversarialBL()
+        public void TestIntersectsNearPixelScaleBoundaryBL()
         {
             CheckIntersects(true, 0, -1, 1,
                 -1.0, -1.0000000000002, -0.4999999999998, -1.4000000000002);

--- a/test/NetTopologySuite.Tests.NUnit/Noding/Snapround/HotPixelTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Noding/Snapround/HotPixelTest.cs
@@ -268,6 +268,24 @@ namespace NetTopologySuite.Tests.NUnit.Noding.Snaparound
             bool actual = hp.Intersects(p1, p2);
             Assert.That(actual, Is.EqualTo(expected));
         }
+
+        // Oracle-driven linear baseline hardening (Cycle 2): pin adversarial sub-ulp passes-through cases
+        // from Proofs oracle (passes_through_proof_vectors.txt). These are the machine-checked unsound
+        // rounded FILTER over-accept cases (#66). Current NTS HotPixel returns TRUE on these vectors
+        // (matches FILTER); full rejection to match EXACT is a desired future hardening.
+        [Test]
+        public void TestOracleSubUlpAdversarialBR()
+        {
+            CheckIntersects(true, 0, -1, 1,
+                1.0, -1.0000000000002, 0.4999999999998, -1.4000000000002);
+        }
+
+        [Test]
+        public void TestOracleSubUlpAdversarialBL()
+        {
+            CheckIntersects(true, 0, -1, 1,
+                -1.0, -1.0000000000002, -0.4999999999998, -1.4000000000002);
+        }
     }
 
 }

--- a/test/NetTopologySuite.Tests.NUnit/Operation/Buffer/BufferTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Operation/Buffer/BufferTest.cs
@@ -897,5 +897,37 @@ namespace NetTopologySuite.Tests.NUnit.Operation.Buffer
             }
             return false;
         }
+
+        /// <summary>
+        /// Oracle-driven linear baseline hardening (Cycle 3, #65 Buffer): Buffer must not mutate
+        /// input coordinates. The BufferInputLineSimplifier (used for linear/ring offset curves,
+        /// negative distances, collapse cases) previously returned shared Coordinate instances
+        /// from CollapseLine. Fixed by copying (consistent with baseline VW/ConvexHull etc. fixes).
+        /// </summary>
+        [Test]
+        public void TestBufferDoesNotMutateInputCoordinates()
+        {
+            var input = Read("LINESTRING (0 0, 5 1, 10 0)");
+            var orig1 = input.Coordinates[1].Copy();
+
+            _ = input.Buffer(1.0);   // exercises simplifier path for line
+
+            Assert.That(input.Coordinates[1].Equals2D(orig1), Is.True, "Input coordinate was mutated by buffer");
+        }
+
+        /// <summary>
+        /// Cycle 5 target: linear thin/near-degenerate buffer (thin rect) for no spurious fragments
+        /// or incorrect holes on collapse/negative (cf. oracle buffer_region + hole979 precision
+        /// hole removal on rects; holes_disjoint linear squares). 
+        /// </summary>
+        [Test]
+        public void TestBufferThinLinearNoSpurious()
+        {
+            var thinRect = Read("POLYGON((0 0, 100 0, 100 0.1, 0 0.1, 0 0))");
+            var bufSmallNeg = thinRect.Buffer(-0.01);
+            // Expect clean (empty or single poly, no spurious extra fragments/holes)
+            Assert.That(bufSmallNeg.NumGeometries <= 1);
+            if (!bufSmallNeg.IsEmpty) Assert.That(bufSmallNeg.Area > 0);
+        }
     }
 }

--- a/test/NetTopologySuite.Tests.NUnit/Operation/Buffer/BufferTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Operation/Buffer/BufferTest.cs
@@ -899,10 +899,8 @@ namespace NetTopologySuite.Tests.NUnit.Operation.Buffer
         }
 
         /// <summary>
-        /// Oracle-driven linear baseline hardening (Cycle 3, #65 Buffer): Buffer must not mutate
-        /// input coordinates. The BufferInputLineSimplifier (used for linear/ring offset curves,
-        /// negative distances, collapse cases) previously returned shared Coordinate instances
-        /// from CollapseLine. Fixed by copying (consistent with baseline VW/ConvexHull etc. fixes).
+        /// Buffer must not mutate caller coordinates. CollapseLine used to
+        /// return the same Coordinate instances as the input line.
         /// </summary>
         [Test]
         public void TestBufferDoesNotMutateInputCoordinates()
@@ -916,9 +914,8 @@ namespace NetTopologySuite.Tests.NUnit.Operation.Buffer
         }
 
         /// <summary>
-        /// Cycle 5 target: linear thin/near-degenerate buffer (thin rect) for no spurious fragments
-        /// or incorrect holes on collapse/negative (cf. oracle buffer_region + hole979 precision
-        /// hole removal on rects; holes_disjoint linear squares). 
+        /// A thin rectangle eroded by a small negative buffer should not
+        /// produce extra fragments or holes.
         /// </summary>
         [Test]
         public void TestBufferThinLinearNoSpurious()

--- a/test/NetTopologySuite.Tests.NUnit/Operation/OverlayNG/OverlayNGTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Operation/OverlayNG/OverlayNGTest.cs
@@ -571,5 +571,24 @@ namespace NetTopologySuite.Tests.NUnit.Operation.OverlayNG
             var expected = Read("LINESTRING (20 50, 80 50)");
             CheckEqual(expected, Intersection(a, b));
         }
+
+        /// <summary>
+        /// Oracle-driven linear baseline (Cycle 4): OverlayNG on linear inputs must not mutate
+        /// input coordinates. Edge stores a copy of pts (was direct reference). Complements
+        /// Cycle 3 buffer copy fix. Relevant for snap-rounding + overlay linear cases (#66).
+        /// </summary>
+        [Test]
+        public void TestOverlayNGDoesNotMutateInputCoordinates_Linear()
+        {
+            var inputA = Read("LINESTRING (0 0, 10 0, 20 0)");
+            var inputB = Read("LINESTRING (5 -5, 5 5)");
+            var orig = inputA.Coordinates[1].Copy();
+
+            var result = Intersection(inputA, inputB);  // linear overlay path
+
+            Assert.That(inputA.Coordinates[1].Equals2D(orig), Is.True);
+            // also ensure no shared instance with what was passed to Edge
+            Assert.That(inputA.Coordinates[1] == orig, Is.False);
+        }
     }
 }

--- a/test/NetTopologySuite.Tests.NUnit/Operation/OverlayNG/OverlayNGTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Operation/OverlayNG/OverlayNGTest.cs
@@ -573,9 +573,8 @@ namespace NetTopologySuite.Tests.NUnit.Operation.OverlayNG
         }
 
         /// <summary>
-        /// Oracle-driven linear baseline (Cycle 4): OverlayNG on linear inputs must not mutate
-        /// input coordinates. Edge stores a copy of pts (was direct reference). Complements
-        /// Cycle 3 buffer copy fix. Relevant for snap-rounding + overlay linear cases (#66).
+        /// OverlayNG must not mutate caller coordinates. Edge used to store
+        /// the incoming point array by reference.
         /// </summary>
         [Test]
         public void TestOverlayNGDoesNotMutateInputCoordinates_Linear()

--- a/test/NetTopologySuite.Tests.NUnit/Operation/RelateNG/RelateNGTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Operation/RelateNG/RelateNGTest.cs
@@ -735,20 +735,15 @@ namespace NetTopologySuite.Tests.NUnit.Operation.RelateNG
             CheckPrepared(a, b);
         }
 
-        // Oracle-driven pinning for area-rect regimes (Cycle 5 target from de9im_area_area_vectors.txt)
-        // NTS produces "full" exterior fill; oracle witnesses use minimal F forms for touch/overlap.
-        // Pinned current NTS behaviour for linear baseline.
+        // Two unit squares that share a vertical edge. Pins the current
+        // DE-9IM (connected exterior, EE=2). Touch is expressed by BB=1.
         [Test]
-        public void TestAreaRectTouchVertical_OracleWitness()
+        public void TestAreaRectTouchVertical()
         {
-            // From oracle: REGIME TOUCH RECT_A 0 0 1 1 , RECT_B 1 0 2 1 -> aa_matrix_touch_vertical
-            // Oracle witness: FFFF1FFF2 ; NTS: FF2F11212 (EE=2 etc for connected exterior)
             var a = Read("POLYGON((0 0,1 0,1 1,0 1,0 0))");
             var b = Read("POLYGON((1 0,2 0,2 1,1 1,1 0))");
-            var im = a.Relate(b);  // or RelateNG
-            Assert.That(im.ToString(), Is.EqualTo("FF2F11212"));  // current NTS full-exterior matrix
-            // Note: oracle witness FFFF1FFF2 (aa_matrix_touch_vertical) for proof regime.
-            // Touch is expressed via BB=1 + boundary predicates; "T********" does not hold for this matrix.
+            var im = a.Relate(b);
+            Assert.That(im.ToString(), Is.EqualTo("FF2F11212"));
         }
     }
 }

--- a/test/NetTopologySuite.Tests.NUnit/Operation/RelateNG/RelateNGTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Operation/RelateNG/RelateNGTest.cs
@@ -735,5 +735,20 @@ namespace NetTopologySuite.Tests.NUnit.Operation.RelateNG
             CheckPrepared(a, b);
         }
 
+        // Oracle-driven pinning for area-rect regimes (Cycle 5 target from de9im_area_area_vectors.txt)
+        // NTS produces "full" exterior fill; oracle witnesses use minimal F forms for touch/overlap.
+        // Pinned current NTS behaviour for linear baseline.
+        [Test]
+        public void TestAreaRectTouchVertical_OracleWitness()
+        {
+            // From oracle: REGIME TOUCH RECT_A 0 0 1 1 , RECT_B 1 0 2 1 -> aa_matrix_touch_vertical
+            // Oracle witness: FFFF1FFF2 ; NTS: FF2F11212 (EE=2 etc for connected exterior)
+            var a = Read("POLYGON((0 0,1 0,1 1,0 1,0 0))");
+            var b = Read("POLYGON((1 0,2 0,2 1,1 1,1 0))");
+            var im = a.Relate(b);  // or RelateNG
+            Assert.That(im.ToString(), Is.EqualTo("FF2F11212"));  // current NTS full-exterior matrix
+            // Note: oracle witness FFFF1FFF2 (aa_matrix_touch_vertical) for proof regime.
+            // Touch is expressed via BB=1 + boundary predicates; "T********" does not hold for this matrix.
+        }
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
topic: metric
witness: mic-radius
claimId: none
issue: #813

PO override of the ML.6 ATTEMPTED park. NTS #813 public TAG: API port of JTS `MaximumInscribedCircle.isRadiusWithin` plus auto-tolerance. **Not a curve laser.** Does not block ML.1.

Port of JTS f76d2245.

## Witness

Diamond `POLYGON ((150 250, 50 150, 150 50, 250 150, 150 250))`: `IsRadiusWithin` is false at 70, true at 71 (MIC radius ≈ 70.71).

## Surface

- `MaximumInscribedCircle.IsRadiusWithin` (static + instance), envelope short-circuit, search termination
- Zero tolerance → `AUTO_TOLERANCE_FRACTION` on MIC and LEC
- Additive `GetCenter` / `GetRadiusLine` / no-tolerance constructors
- Existing positive-tolerance callers unchanged

## Checks

`dotnet test` filter `MaximumInscribedCircle|MaxInscribedCircleRadiusWithin|LargestEmptyCircleTest`: **21 passed**, 1 skipped (pre-existing `TestLinesZigzag` Ignore).

No ExactMaxInscribedCircle zoo. No ML.1 stadium. No ML.3.

AI-drafted, human-reviewed. By contributing, authors agree the work may be used under the project license.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc93a9b6-cabf-416a-943d-5dcc8901ccfa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc93a9b6-cabf-416a-943d-5dcc8901ccfa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

