### PR TITLE
WKT: name SQL/MM §4.2.1 curve types and refuse

### DIFF
--- a/src/NetTopologySuite/IO/WKTConstants.cs
+++ b/src/NetTopologySuite/IO/WKTConstants.cs
@@ -63,6 +63,37 @@ namespace NetTopologySuite.IO
         public const string TIN = "TIN";
 
         /// <summary>
+        /// Token text for ISO/IEC 13249-3 §4.2.7 ST_Circle. Instantiable;
+        /// NTS has no carrier yet — the reader names the type and refuses.
+        /// </summary>
+        public const string CIRCLE = "CIRCLE";
+        /// <summary>
+        /// Token text for ISO/IEC 13249-3 §4.2.8 ST_GeodesicString.
+        /// Instantiable; named refuse until a carrier exists.
+        /// </summary>
+        public const string GEODESICSTRING = "GEODESICSTRING";
+        /// <summary>
+        /// Token text for ISO/IEC 13249-3 §4.2.9 ST_EllipticalCurve.
+        /// Instantiable; named refuse until a carrier exists.
+        /// </summary>
+        public const string ELLIPTICALCURVE = "ELLIPTICALCURVE";
+        /// <summary>
+        /// Token text for ISO/IEC 13249-3 §4.2.10 ST_NURBSCurve.
+        /// Instantiable; named refuse until a carrier exists.
+        /// </summary>
+        public const string NURBSCURVE = "NURBSCURVE";
+        /// <summary>
+        /// Token text for ISO/IEC 13249-3 §4.2.11 ST_Clothoid.
+        /// Instantiable; named refuse until a carrier exists.
+        /// </summary>
+        public const string CLOTHOID = "CLOTHOID";
+        /// <summary>
+        /// Token text for ISO/IEC 13249-3 §4.2.12 ST_SpiralCurve.
+        /// Instantiable; named refuse until a carrier exists.
+        /// </summary>
+        public const string SPIRALCURVE = "SPIRALCURVE";
+
+        /// <summary>
         /// Token text for empty geometries
         /// </summary>
         public const string EMPTY = "EMPTY";

--- a/src/NetTopologySuite/IO/WKTReader.cs
+++ b/src/NetTopologySuite/IO/WKTReader.cs
@@ -775,6 +775,8 @@ namespace NetTopologySuite.IO
                 returned = ReadTriangleText(tokens, factory, ordinateFlags);
             else if (IsTypeName(tokens, type, WKTConstants.TIN))
                 returned = ReadTinText(tokens, factory, ordinateFlags);
+            else if (IsUnimplementedSqlMmCurve(type))
+                throw SqlMmUnimplemented(type);
             else throw new ParseException("Unknown type: " + type);
 
             if (returned == null)
@@ -800,6 +802,43 @@ namespace NetTopologySuite.IO
             }
     
             return true;
+        }
+
+        /// <summary>
+        /// True when <paramref name="type"/> is <paramref name="typeName"/>
+        /// with an optional Z / M / ZM suffix. Unlike <see cref="IsTypeName"/>,
+        /// a longer leftover (CIRCULARSTRING vs CIRCLE) is not an error — it
+        /// is simply not a match.
+        /// </summary>
+        private static bool HasTypeNameWithDimSuffix(string type, string typeName)
+        {
+            if (!type.StartsWith(typeName, StringComparison.OrdinalIgnoreCase))
+                return false;
+            string modifiers = type.Substring(typeName.Length);
+            return modifiers.Length == 0
+                || modifiers.Equals(WKTConstants.Z, StringComparison.OrdinalIgnoreCase)
+                || modifiers.Equals(WKTConstants.M, StringComparison.OrdinalIgnoreCase)
+                || modifiers.Equals(WKTConstants.ZM, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Instantiable ST_Curve subtypes in ISO/IEC 13249-3 §4.2.1 that NTS
+        /// does not yet carry. Not optional extras. Do not call them unknown.
+        /// </summary>
+        private static bool IsUnimplementedSqlMmCurve(string type)
+        {
+            return HasTypeNameWithDimSuffix(type, WKTConstants.CLOTHOID)
+                || HasTypeNameWithDimSuffix(type, WKTConstants.CIRCLE)
+                || HasTypeNameWithDimSuffix(type, WKTConstants.GEODESICSTRING)
+                || HasTypeNameWithDimSuffix(type, WKTConstants.ELLIPTICALCURVE)
+                || HasTypeNameWithDimSuffix(type, WKTConstants.NURBSCURVE)
+                || HasTypeNameWithDimSuffix(type, WKTConstants.SPIRALCURVE);
+        }
+
+        private static ParseException SqlMmUnimplemented(string type)
+        {
+            return new ParseException(
+                "SQL/MM type is not optional (ISO/IEC 13249-3 §4.2.1) and is not implemented: " + type);
         }
 
 /// <summary>
@@ -1077,6 +1116,9 @@ private Point ReadPointText(TokenStream tokens, GeometryFactory factory, Ordinat
                 GetNextWord(tokens);
                 return ReadCompoundCurveText(tokens, factory, ordinateFlags);
             }
+
+            if (IsUnimplementedSqlMmCurve(current))
+                throw SqlMmUnimplemented(current);
 
             throw new ParseException("Unexpected token: " + current);
         }

--- a/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/CurveWktTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Geometries/Curves/CurveWktTest.cs
@@ -107,5 +107,30 @@ namespace NetTopologySuite.Tests.NUnit.Geometries.Curves
             Assert.Throws<ArgumentException>(() =>
                 new WKTReader().Read("COMPOUNDCURVE ((0 0, 1 0), (2 0, 3 0))"));
         }
+
+        [TestCase("CLOTHOID EMPTY")]
+        [TestCase("CIRCLE EMPTY")]
+        [TestCase("GEODESICSTRING EMPTY")]
+        [TestCase("NURBSCURVE EMPTY")]
+        [TestCase("SPIRALCURVE EMPTY")]
+        [TestCase("ELLIPTICALCURVE EMPTY")]
+        [TestCase("CLOTHOID Z EMPTY")]
+        [TestCase("COMPOUNDCURVE (CLOTHOID EMPTY)")]
+        public void SqlMmSection421TypesAreNamedRefusesNotUnknown(string wkt)
+        {
+            var ex = Assert.Throws<ParseException>(() => new WKTReader().Read(wkt));
+            Assert.That(ex.Message, Does.Contain("not optional"));
+            Assert.That(ex.Message, Does.Contain("13249-3"));
+            Assert.That(ex.Message, Does.Not.Contain("Unknown type"));
+            Assert.That(ex.Message, Does.Not.Contain("Unexpected token"));
+        }
+
+        [Test]
+        public void GenuineUnknownTypeStaysUnknown()
+        {
+            var ex = Assert.Throws<ParseException>(() => new WKTReader().Read("NOTATYPE (0 0)"));
+            Assert.That(ex.Message, Does.Contain("Unknown type"));
+            Assert.That(ex.Message, Does.Not.Contain("not optional"));
+        }
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository.
- [x] I have provided test coverage for my change (where applicable)

### Description

`ST_Clothoid`, `ST_Circle`, `ST_GeodesicString`, `ST_NURBSCurve`, `ST_SpiralCurve`, and `ST_EllipticalCurve` are instantiable ST_Curve subtypes in ISO/IEC 13249-3 §4.2.1. They are not optional extras. This reader used to call them `Unknown type`. That is a lie.

Named refuse, matching GEOS: the message cites §4.2.1 and does not say `Unknown type`. A genuine unknown token (`NOTATYPE`) still does. `COMPOUNDCURVE (CLOTHOID …)` hits the same refuse, not `Unexpected token`. CIRCLE does not steal CIRCULARSTRING (dim-suffix match, not `IsTypeName`).

No carrier. No flatten to LINESTRING. Do not remint 508. Type-9/10/11/12 reader PRs stay out.

Pins: `CurveWktTest.SqlMmSection421TypesAreNamedRefusesNotUnknown` (31 CurveWktTest passed locally).

Companion Proofs letter: https://github.com/grootstebozewolf/NetTopologySuite.Proofs/pull/660 (ticket 38).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc93a9b6-cabf-416a-943d-5dcc8901ccfa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc93a9b6-cabf-416a-943d-5dcc8901ccfa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

