### PR TITLE
Merge fuller DirectedHausdorff port onto port/directed-hausdorff

### DIFF
--- a/src/NetTopologySuite/Algorithm/Distance/DirectedHausdorffDistance.cs
+++ b/src/NetTopologySuite/Algorithm/Distance/DirectedHausdorffDistance.cs
@@ -1,0 +1,685 @@
+using System;
+using System.Collections.Generic;
+using NetTopologySuite.Algorithm.Construct;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.Operation.Distance;
+using NetTopologySuite.Utilities;
+using Point = NetTopologySuite.Geometries.Point;
+
+namespace NetTopologySuite.Algorithm.Distance
+{
+    /// <summary>
+    /// Computes the directed Hausdorff distance from one geometry to another.
+    /// The directed Hausdorff distance is the maximum distance any point
+    /// on a query geometry A can be from a target geometry B.
+    /// Equivalently, every point in the query geometry is within that distance
+    /// of the target geometry.
+    /// The class can compute a pair of points at which the distance is attained:
+    /// <c>[ farthest A point, nearest B point ]</c>.
+    /// <para/>
+    /// The directed Hausdorff distance (DHD) is defined as:
+    /// <code>
+    /// DHD(A, B) = max(a in A)  max(b in B)  distance(a, b)
+    /// </code>
+    /// DHD is asymmetric: <c>DHD(A, B)</c> may not be equal to <c>DHD(B, A)</c>.
+    /// Hence it is not a distance metric.
+    /// The Hausdorff distance is a symmetric distance metric defined as:
+    /// <code>
+    /// HD(A, B) = max(DHD(A, B), DHD(B, A))
+    /// </code>
+    /// This can be computed via the <see cref="HausdorffDistancePoints"/> function.
+    /// <para/>
+    /// Points, lines and polygons are supported as input.
+    /// If the query geometry is polygonal,
+    /// the point at maximum distance may occur in the interior of a query polygon.
+    /// For a polygonal target geometry the point always lies on the boundary.
+    /// <para/>
+    /// The directed Hausdorff distance can be used to test
+    /// whether a geometry lies fully within a given distance of another one.
+    /// The <see cref="IsFullyWithinDistance(Geometry, Geometry, double)"/> function
+    /// is provided to execute this test efficiently. It implements heuristic checks
+    /// and short-circuiting to improve performance.
+    /// <para/>
+    /// The class can be used in prepared mode.
+    /// Creating an instance on a target geometry caches indexes for that geometry.
+    /// Then <see cref="FarthestPoints(Geometry)"/> or <see cref="IsFullyWithinDistance(Geometry, double)"/>
+    /// can be called efficiently for multiple query geometries.
+    /// <para/>
+    /// If the Hausdorff distance is attained at a non-vertex of the query geometry,
+    /// the location must be approximated. The algorithm uses a distance tolerance
+    /// to control the approximation accuracy. The tolerance is automatically determined
+    /// to balance between accuracy and performance. If more accuracy is desired some
+    /// function signatures are provided which allow specifying a distance tolerance.
+    /// <para/>
+    /// This algorithm is easier to use, more accurate, and much faster than
+    /// <see cref="DiscreteHausdorffDistance"/>.
+    /// </summary>
+    /// <author>Martin Davis</author>
+    public class DirectedHausdorffDistance
+    {
+        private const double EmptyDistance = double.NaN;
+
+        /// <summary>Heuristic automatic tolerance factor.</summary>
+        private const double AutoToleranceFactor = 1.0e4;
+
+        /// <summary>
+        /// Heuristic factor to improve performance of area interior farthest point computation.
+        /// The LargestEmptyCircle computation is much slower than the boundary one,
+        /// is unlikely to occur, and accuracy is less critical (and obvious).
+        /// </summary>
+        private const double AreaInteriorToleranceFactor = 20;
+
+        /// <summary>
+        /// Tolerance factor for <see cref="IsFullyWithinDistance(Geometry, double)"/>.
+        /// A larger factor is used to increase accuracy. The operation will usually short-circuit,
+        /// so performance impact is low.
+        /// </summary>
+        private const double FullyWithinToleranceFactor = 10 * AutoToleranceFactor;
+
+        /// <summary>
+        /// Computes the directed Hausdorff distance of a query geometry A from a target one B.
+        /// </summary>
+        /// <param name="a">The query geometry</param>
+        /// <param name="b">The target geometry</param>
+        /// <returns>The directed Hausdorff distance, or <c>NaN</c> if an input is empty</returns>
+        public static double Distance(Geometry a, Geometry b)
+        {
+            var hd = new DirectedHausdorffDistance(b);
+            return Distance(hd.FarthestPoints(a));
+        }
+
+        /// <summary>
+        /// Computes the directed Hausdorff distance of a query geometry A from a target one B,
+        /// up to a given distance accuracy.
+        /// </summary>
+        /// <param name="a">The query geometry</param>
+        /// <param name="b">The target geometry</param>
+        /// <param name="tolerance">The accuracy distance tolerance</param>
+        /// <returns>The directed Hausdorff distance, or <c>NaN</c> if an input is empty</returns>
+        public static double Distance(Geometry a, Geometry b, double tolerance)
+        {
+            var hd = new DirectedHausdorffDistance(b);
+            return Distance(hd.FarthestPoints(a, tolerance));
+        }
+
+        /// <summary>
+        /// Computes a pair of points which attain the directed Hausdorff distance
+        /// of a query geometry A from a target one B.
+        /// </summary>
+        /// <param name="a">The query geometry</param>
+        /// <param name="b">The target geometry</param>
+        /// <returns>A pair of points <c>[ptA, ptB]</c> demonstrating the distance, or <c>null</c> if an input is empty</returns>
+        public static Coordinate[] DistancePoints(Geometry a, Geometry b)
+        {
+            var dhd = new DirectedHausdorffDistance(b);
+            return dhd.FarthestPoints(a);
+        }
+
+        /// <summary>
+        /// Computes a pair of points which attain the directed Hausdorff distance
+        /// of a query geometry A from a target one B, up to a given distance accuracy.
+        /// </summary>
+        /// <param name="a">The query geometry</param>
+        /// <param name="b">The target geometry</param>
+        /// <param name="tolerance">The accuracy distance tolerance</param>
+        /// <returns>A pair of points <c>[ptA, ptB]</c> demonstrating the distance, or <c>null</c> if an input is empty</returns>
+        public static Coordinate[] DistancePoints(Geometry a, Geometry b, double tolerance)
+        {
+            var dhd = new DirectedHausdorffDistance(b);
+            return dhd.FarthestPoints(a, tolerance);
+        }
+
+        /// <summary>
+        /// Computes a pair of points which attain the symmetric Hausdorff distance between two geometries.
+        /// This is the maximum of the two directed Hausdorff distances.
+        /// </summary>
+        /// <param name="a">A geometry</param>
+        /// <param name="b">A geometry</param>
+        /// <returns>A pair of points <c>[ptA, ptB]</c> demonstrating the Hausdorff distance, or <c>null</c> if an input is empty</returns>
+        public static Coordinate[] HausdorffDistancePoints(Geometry a, Geometry b)
+        {
+            var hdAB = new DirectedHausdorffDistance(b);
+            var ptsAB = hdAB.FarthestPoints(a);
+            var hdBA = new DirectedHausdorffDistance(a);
+            var ptsBA = hdBA.FarthestPoints(b);
+
+            //-- return points in A-B order
+            var pts = ptsAB;
+            if (Distance(ptsBA) > Distance(ptsAB))
+            {
+                //-- reverse the BA points
+                pts = Pair(ptsBA[1], ptsBA[0]);
+            }
+            return pts;
+        }
+
+        /// <summary>
+        /// Computes the symmetric Hausdorff distance between two geometries.
+        /// This is the maximum of the two directed Hausdorff distances.
+        /// </summary>
+        /// <param name="a">A geometry</param>
+        /// <param name="b">A geometry</param>
+        /// <returns>The Hausdorff distance, or <c>NaN</c> if an input is empty</returns>
+        public static double HausdorffDistance(Geometry a, Geometry b)
+        {
+            return Distance(HausdorffDistancePoints(a, b));
+        }
+
+        /// <summary>
+        /// Computes whether a query geometry lies fully within a given distance of a target geometry.
+        /// </summary>
+        public static bool IsFullyWithinDistance(Geometry a, Geometry b, double maxDistance)
+        {
+            var hd = new DirectedHausdorffDistance(b);
+            return hd.IsFullyWithinDistance(a, maxDistance);
+        }
+
+        /// <summary>
+        /// Computes whether a query geometry lies fully within a given distance of a target geometry,
+        /// up to a given distance accuracy.
+        /// </summary>
+        public static bool IsFullyWithinDistance(Geometry a, Geometry b, double maxDistance, double tolerance)
+        {
+            var hd = new DirectedHausdorffDistance(b);
+            return hd.IsFullyWithinDistance(a, maxDistance, tolerance);
+        }
+
+        private static double Distance(Coordinate[] pts)
+        {
+            if (pts == null)
+                return EmptyDistance;
+            return pts[0].Distance(pts[1]);
+        }
+
+        private static Coordinate[] Pair(Coordinate p0, Coordinate p1)
+        {
+            return new[] { p0.Copy(), p1.Copy() };
+        }
+
+        private static double ComputeTolerance(Geometry geom)
+        {
+            return geom.EnvelopeInternal.Diameter / AutoToleranceFactor;
+        }
+
+        private readonly Geometry _target;
+        private readonly TargetDistance _targetDistance;
+
+        /// <summary>
+        /// Create a new instance for a target geometry.
+        /// </summary>
+        /// <param name="geom">The geometry to compute the distance from</param>
+        public DirectedHausdorffDistance(Geometry geom)
+        {
+            _target = geom;
+            _targetDistance = new TargetDistance(_target);
+        }
+
+        /// <summary>
+        /// Tests whether a query geometry lies fully within a given distance of the target geometry.
+        /// </summary>
+        public bool IsFullyWithinDistance(Geometry geom, double maxDistance)
+        {
+            double tolerance = maxDistance / FullyWithinToleranceFactor;
+            return IsFullyWithinDistance(geom, maxDistance, tolerance);
+        }
+
+        /// <summary>
+        /// Tests whether a query geometry lies fully within a given distance of the target geometry,
+        /// up to a given distance accuracy.
+        /// </summary>
+        public bool IsFullyWithinDistance(Geometry geom, double maxDistance, double tolerance)
+        {
+            //-- envelope checks
+            if (IsBeyond(geom.EnvelopeInternal, _target.EnvelopeInternal, maxDistance))
+                return false;
+
+            var maxDistCoords = ComputeDistancePoints(geom, tolerance, maxDistance);
+            //-- handle empty case
+            if (maxDistCoords == null)
+                return false;
+            return Distance(maxDistCoords) <= maxDistance;
+        }
+
+        /// <summary>
+        /// Tests if an envelope must have a side farther than the maximum distance from another envelope.
+        /// </summary>
+        private static bool IsBeyond(Envelope envA, Envelope envB, double maxDistance)
+        {
+            return envA.MinX < envB.MinX - maxDistance
+                || envA.MinY < envB.MinY - maxDistance
+                || envA.MaxX > envB.MaxX + maxDistance
+                || envA.MaxY > envB.MaxY + maxDistance;
+        }
+
+        /// <summary>
+        /// Computes a pair of points which attain the directed Hausdorff distance
+        /// of a query geometry A from the target B.
+        /// </summary>
+        public Coordinate[] FarthestPoints(Geometry geom)
+        {
+            double tolerance = ComputeTolerance(geom);
+            return FarthestPoints(geom, tolerance);
+        }
+
+        /// <summary>
+        /// Computes a pair of points which attain the directed Hausdorff distance
+        /// of a query geometry A from the target B, up to a given distance accuracy.
+        /// </summary>
+        public Coordinate[] FarthestPoints(Geometry geom, double tolerance)
+        {
+            return ComputeDistancePoints(geom, tolerance, -1.0);
+        }
+
+        private Coordinate[] ComputeDistancePoints(Geometry geom, double tolerance, double maxDistanceLimit)
+        {
+            //-- Negative tolerances are not allowed.
+            //-- Zero tolerance is allowed, to support zero-size input.
+            if (tolerance < 0.0)
+                throw new ArgumentException("Tolerance must be non-negative", nameof(tolerance));
+
+            if (geom.IsEmpty || _target.IsEmpty)
+                return null;
+
+            if (geom.Dimension == Dimension.Point)
+            {
+                return ComputeForPoints(geom, maxDistanceLimit);
+            }
+
+            var maxDistPtsEdge = ComputeForEdges(geom, tolerance, maxDistanceLimit);
+
+            if (IsBeyondLimit(Distance(maxDistPtsEdge), maxDistanceLimit))
+            {
+                return maxDistPtsEdge;
+            }
+
+            //-- Polygonal query geometry may have an interior point as the farthest point.
+            if (geom.Dimension == Dimension.Surface)
+            {
+                var maxDistPtsInterior = ComputeForAreaInterior(geom, tolerance);
+                if (maxDistPtsInterior != null
+                    && Distance(maxDistPtsInterior) > Distance(maxDistPtsEdge))
+                {
+                    return maxDistPtsInterior;
+                }
+            }
+            return maxDistPtsEdge;
+        }
+
+        private Coordinate[] ComputeForPoints(Geometry geom, double maxDistanceLimit)
+        {
+            double maxDist = -1.0;
+            Coordinate[] maxDistPtsAB = null;
+            var geomi = new GeometryCollectionEnumerator(geom);
+            while (geomi.MoveNext())
+            {
+                var geomElem = geomi.Current;
+                if (!(geomElem is Point))
+                    continue;
+
+                var pA = geomElem.Coordinate;
+                var pB = _targetDistance.NearestPoint(pA);
+                double dist = pA.Distance(pB);
+
+                bool isInterior = dist > 0 && _targetDistance.IsInterior(pA);
+                //-- check for interior point
+                if (isInterior)
+                {
+                    dist = 0;
+                    pB = pA;
+                }
+                if (dist > maxDist)
+                {
+                    maxDist = dist;
+                    maxDistPtsAB = Pair(pA, pB);
+                }
+                if (IsValidLimit(maxDistanceLimit)
+                    && IsBeyondLimit(maxDist, maxDistanceLimit))
+                {
+                    break;
+                }
+            }
+            return maxDistPtsAB;
+        }
+
+        private Coordinate[] ComputeForEdges(Geometry geom, double tolerance, double maxDistanceLimit)
+        {
+            var segQueue = CreateSegQueue(geom);
+
+            DhdSegment segMaxDist = null;
+            while (!segQueue.IsEmpty())
+            {
+                // get the segment with greatest distance bound
+                var segMaxBound = segQueue.Poll();
+
+                //-- Save if segment point is farther than current farthest
+                if (segMaxDist == null
+                    || segMaxBound.MaxDistance > segMaxDist.MaxDistance)
+                {
+                    segMaxDist = segMaxBound;
+                }
+
+                //-- Stop searching if remaining items must all be closer than current maximum.
+                if (segMaxBound.MaxDistanceBound <= segMaxDist.MaxDistance)
+                {
+                    break;
+                }
+
+                //-- If maxDistanceLimit is specified, can stop searching in two cases.
+                if (IsValidLimit(maxDistanceLimit))
+                {
+                    if (IsWithinLimit(segMaxBound.MaxDistanceBound, maxDistanceLimit)
+                        || IsBeyondLimit(segMaxBound.MaxDistance, maxDistanceLimit))
+                    {
+                        break;
+                    }
+                }
+
+                //-- Equal-or-collinear segments don't need further bisection.
+                //-- This greatly improves performance when inputs are identical/collinear.
+                if (segMaxBound.MaxDistance == 0.0)
+                {
+                    if (IsSameOrCollinear(segMaxBound))
+                        continue;
+                }
+
+                //-- If segment is longer than tolerance, bisect and keep searching.
+                if (tolerance > 0
+                    && segMaxBound.Length > tolerance)
+                {
+                    var bisects = segMaxBound.Bisect(_targetDistance);
+                    AddNonInterior(bisects[0], segQueue);
+                    AddNonInterior(bisects[1], segQueue);
+                }
+            }
+
+            if (segMaxDist != null)
+                return segMaxDist.GetMaxDistPts();
+
+            //-- No DHD segment was found: all were inside the target.
+            //-- In this case distance is zero. Return a single coordinate as a representative point.
+            var maxPt = geom.Coordinate;
+            return Pair(maxPt, maxPt);
+        }
+
+        private bool IsSameOrCollinear(DhdSegment seg)
+        {
+            var f0 = _targetDistance.NearestLocation(seg.P0);
+            var f1 = _targetDistance.NearestLocation(seg.P1);
+            return IsSameSegment(f0, f1);
+        }
+
+        private static bool IsSameSegment(GeometryLocation a, GeometryLocation b)
+        {
+            if (a == null || b == null) return false;
+            return ReferenceEquals(a.GeometryComponent, b.GeometryComponent)
+                && a.SegmentIndex == b.SegmentIndex;
+        }
+
+        private static bool IsValidLimit(double limit) => limit >= 0.0;
+
+        private static bool IsBeyondLimit(double maxDist, double maxDistanceLimit)
+            => maxDistanceLimit >= 0 && maxDist > maxDistanceLimit;
+
+        private static bool IsWithinLimit(double maxDist, double maxDistanceLimit)
+            => maxDistanceLimit >= 0 && maxDist <= maxDistanceLimit;
+
+        private void AddNonInterior(DhdSegment segment, PriorityQueue<DhdSegment> segQueue)
+        {
+            //-- discard segment if it is interior to a polygon
+            if (IsInterior(segment))
+                return;
+            //-- DhdSegment.CompareTo inverts ordering so Poll() returns the segment with greatest bound.
+            segQueue.Add(segment);
+        }
+
+        /// <summary>
+        /// Tests if segment is fully in the interior of the target geometry polygons (if any).
+        /// </summary>
+        private bool IsInterior(DhdSegment segment)
+        {
+            if (segment.MaxDistance > 0.0)
+                return false;
+            return _targetDistance.IsInterior(segment.Endpoint(0), segment.Endpoint(1));
+        }
+
+        /// <summary>
+        /// If the query geometry is polygonal, it is possible the farthest point lies in its interior.
+        /// In this case it occurs at the centre of the Largest Empty Circle
+        /// with B as obstacles and the query geometry as constraint.
+        /// </summary>
+        private Coordinate[] ComputeForAreaInterior(Geometry geom, double tolerance)
+        {
+            if (tolerance <= 0.0)
+                return null;
+
+            var polygonal = geom;
+
+            //-- Optimization: skip if A interior cannot intersect B,
+            //-- so farthest point must lie on A boundary
+            if (polygonal.EnvelopeInternal.Disjoint(_target.EnvelopeInternal))
+                return null;
+
+            var centerPt = LargestEmptyCircle.GetCenter(_target, polygonal,
+                tolerance * AreaInteriorToleranceFactor);
+            var ptA = centerPt.Coordinate;
+            //-- If LEC centre is in B, the max distance is zero, so return null.
+            if (_targetDistance.IsInterior(ptA))
+                return null;
+            var ptB = _targetDistance.NearestFacetPoint(ptA);
+            return Pair(ptA, ptB);
+        }
+
+        /// <summary>
+        /// Creates the priority queue for segments. Segments which are interior to a polygonal
+        /// target geometry are not added to the queue.
+        /// </summary>
+        private PriorityQueue<DhdSegment> CreateSegQueue(Geometry geom)
+        {
+            var priq = new PriorityQueue<DhdSegment>();
+            geom.Apply(new GeometryComponentFilter(g =>
+            {
+                if (g is LineString line)
+                {
+                    AddSegments(line.Coordinates, priq);
+                }
+            }));
+            return priq;
+        }
+
+        private void AddSegments(Coordinate[] pts, PriorityQueue<DhdSegment> priq)
+        {
+            DhdSegment segMaxDist = null;
+            DhdSegment prevSeg = null;
+            for (int i = 0; i < pts.Length - 1; i++)
+            {
+                DhdSegment seg;
+                if (i == 0)
+                {
+                    seg = DhdSegment.Create(pts[i], pts[i + 1], _targetDistance);
+                }
+                else
+                {
+                    //-- avoid recomputing prev point distance
+                    seg = DhdSegment.Create(prevSeg, pts[i + 1], _targetDistance);
+                }
+                prevSeg = seg;
+
+                //-- don't add segment if it can't be further away than current max
+                if (segMaxDist == null
+                    || seg.MaxDistanceBound > segMaxDist.MaxDistance)
+                {
+                    //-- Don't add interior segments, since their distance must be zero.
+                    AddNonInterior(seg, priq);
+                }
+
+                if (segMaxDist == null
+                    || seg.MaxDistance > segMaxDist.MaxDistance)
+                {
+                    segMaxDist = seg;
+                }
+            }
+        }
+
+        private class TargetDistance
+        {
+            private readonly IndexedFacetDistance _distanceToFacets;
+            private readonly bool _isArea;
+            private readonly IndexedPointInPolygonsLocator _ptInArea;
+
+            public TargetDistance(Geometry geom)
+            {
+                _distanceToFacets = new IndexedFacetDistance(geom);
+                _isArea = (int)geom.Dimension >= (int)Dimension.Surface;
+                if (_isArea)
+                {
+                    _ptInArea = new IndexedPointInPolygonsLocator(geom);
+                }
+            }
+
+            public GeometryLocation NearestLocation(Coordinate p)
+            {
+                return _distanceToFacets.NearestLocation(p);
+            }
+
+            public Coordinate NearestFacetPoint(Coordinate p)
+            {
+                return _distanceToFacets.NearestPoint(p);
+            }
+
+            public Coordinate NearestPoint(Coordinate p)
+            {
+                if (_ptInArea != null)
+                {
+                    if (_ptInArea.Locate(p) != Location.Exterior)
+                    {
+                        return p;
+                    }
+                }
+                return _distanceToFacets.NearestPoint(p);
+            }
+
+            public bool IsInterior(Coordinate p)
+            {
+                if (!_isArea) return false;
+                return _ptInArea.Locate(p) == Location.Interior;
+            }
+
+            public bool IsInterior(Coordinate p0, Coordinate p1)
+            {
+                if (!_isArea)
+                    return false;
+                //-- compute distance to B linework
+                double segDist = _distanceToFacets.Distance(p0, p1);
+                //-- if segment touches B linework it is not in interior
+                if (segDist == 0)
+                    return false;
+                //-- only need to test one point to check interior
+                return IsInterior(p0);
+            }
+        }
+
+        private class DhdSegment : IComparable<DhdSegment>
+        {
+            public static DhdSegment Create(Coordinate p0, Coordinate p1, TargetDistance dist)
+            {
+                var seg = new DhdSegment(p0, p1);
+                seg.Init(dist);
+                return seg;
+            }
+
+            public static DhdSegment Create(DhdSegment prevSeg, Coordinate p1, TargetDistance dist)
+            {
+                var seg = new DhdSegment(prevSeg.P1, p1);
+                seg.Init(prevSeg._nearPt1, dist);
+                return seg;
+            }
+
+            public readonly Coordinate P0;
+            public readonly Coordinate P1;
+            private Coordinate _nearPt0;
+            private Coordinate _nearPt1;
+            private double _maxDistance;
+            private double _maxDistanceBound = double.NegativeInfinity;
+
+            private DhdSegment(Coordinate p0, Coordinate p1)
+            {
+                P0 = p0;
+                P1 = p1;
+            }
+
+            private DhdSegment(Coordinate p0, Coordinate nearPt0, Coordinate p1, Coordinate nearPt1)
+            {
+                P0 = p0;
+                _nearPt0 = nearPt0;
+                P1 = p1;
+                _nearPt1 = nearPt1;
+                ComputeMaxDistances();
+            }
+
+            private void Init(TargetDistance dist)
+            {
+                _nearPt0 = dist.NearestPoint(P0);
+                _nearPt1 = dist.NearestPoint(P1);
+                ComputeMaxDistances();
+            }
+
+            private void Init(Coordinate nearest0, TargetDistance dist)
+            {
+                _nearPt0 = nearest0;
+                _nearPt1 = dist.NearestPoint(P1);
+                ComputeMaxDistances();
+            }
+
+            public Coordinate Endpoint(int index) => index == 0 ? P0 : P1;
+
+            public double Length => P0.Distance(P1);
+
+            public double MaxDistance => _maxDistance;
+
+            public double MaxDistanceBound => _maxDistanceBound;
+
+            public Coordinate[] GetMaxDistPts()
+            {
+                double dist0 = P0.Distance(_nearPt0);
+                double dist1 = P1.Distance(_nearPt1);
+                if (dist0 > dist1)
+                    return new[] { P0.Copy(), _nearPt0.Copy() };
+                return new[] { P1.Copy(), _nearPt1.Copy() };
+            }
+
+            /// <summary>
+            /// Computes a least upper bound for the maximum distance to a segment.
+            /// </summary>
+            private void ComputeMaxDistances()
+            {
+                //-- Least upper bound is the max distance to the endpoints,
+                //-- plus half segment length.
+                double dist0 = P0.Distance(_nearPt0);
+                double dist1 = P1.Distance(_nearPt1);
+                _maxDistance = System.Math.Max(dist0, dist1);
+                _maxDistanceBound = _maxDistance + Length / 2;
+            }
+
+            public DhdSegment[] Bisect(TargetDistance dist)
+            {
+                var mid = new Coordinate((P0.X + P1.X) / 2, (P0.Y + P1.Y) / 2);
+                var nearPtMid = dist.NearestPoint(mid);
+                return new[]
+                {
+                    new DhdSegment(P0, _nearPt0, mid, nearPtMid),
+                    new DhdSegment(mid, nearPtMid, P1, _nearPt1),
+                };
+            }
+
+            /// <summary>
+            /// Inverts natural ordering so that <see cref="NetTopologySuite.Utilities.PriorityQueue{T}.Poll"/>
+            /// returns the segment with the greatest <see cref="MaxDistanceBound"/> first.
+            /// </summary>
+            public int CompareTo(DhdSegment other)
+            {
+                if (other == null) return -1;
+                return -_maxDistanceBound.CompareTo(other._maxDistanceBound);
+            }
+        }
+    }
+}

--- a/src/NetTopologySuite/Algorithm/Distance/DirectedHausdorffDistance.cs
+++ b/src/NetTopologySuite/Algorithm/Distance/DirectedHausdorffDistance.cs
@@ -1,61 +1,53 @@
 using System;
-using System.Collections.Generic;
 using NetTopologySuite.Algorithm.Construct;
 using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
 using NetTopologySuite.Operation.Distance;
 using NetTopologySuite.Utilities;
-using Point = NetTopologySuite.Geometries.Point;
 
 namespace NetTopologySuite.Algorithm.Distance
 {
     /// <summary>
-    /// Computes the directed Hausdorff distance from one geometry to another.
-    /// The directed Hausdorff distance is the maximum distance any point
-    /// on a query geometry A can be from a target geometry B.
-    /// Equivalently, every point in the query geometry is within that distance
-    /// of the target geometry.
-    /// The class can compute a pair of points at which the distance is attained:
-    /// <c>[ farthest A point, nearest B point ]</c>.
-    /// <para/>
-    /// The directed Hausdorff distance (DHD) is defined as:
-    /// <code>
-    /// DHD(A, B) = max(a in A)  max(b in B)  distance(a, b)
-    /// </code>
-    /// DHD is asymmetric: <c>DHD(A, B)</c> may not be equal to <c>DHD(B, A)</c>.
-    /// Hence it is not a distance metric.
-    /// The Hausdorff distance is a symmetric distance metric defined as:
-    /// <code>
-    /// HD(A, B) = max(DHD(A, B), DHD(B, A))
-    /// </code>
-    /// This can be computed via the <see cref="HausdorffDistancePoints"/> function.
-    /// <para/>
-    /// Points, lines and polygons are supported as input.
-    /// If the query geometry is polygonal,
-    /// the point at maximum distance may occur in the interior of a query polygon.
-    /// For a polygonal target geometry the point always lies on the boundary.
-    /// <para/>
-    /// The directed Hausdorff distance can be used to test
-    /// whether a geometry lies fully within a given distance of another one.
-    /// The <see cref="IsFullyWithinDistance(Geometry, Geometry, double)"/> function
-    /// is provided to execute this test efficiently. It implements heuristic checks
-    /// and short-circuiting to improve performance.
-    /// <para/>
-    /// The class can be used in prepared mode.
-    /// Creating an instance on a target geometry caches indexes for that geometry.
-    /// Then <see cref="FarthestPoints(Geometry)"/> or <see cref="IsFullyWithinDistance(Geometry, double)"/>
-    /// can be called efficiently for multiple query geometries.
-    /// <para/>
-    /// If the Hausdorff distance is attained at a non-vertex of the query geometry,
-    /// the location must be approximated. The algorithm uses a distance tolerance
-    /// to control the approximation accuracy. The tolerance is automatically determined
-    /// to balance between accuracy and performance. If more accuracy is desired some
-    /// function signatures are provided which allow specifying a distance tolerance.
-    /// <para/>
-    /// This algorithm is easier to use, more accurate, and much faster than
-    /// <see cref="DiscreteHausdorffDistance"/>.
+    /// Computes the directed Hausdorff distance from a query geometry A
+    /// to a target geometry B.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The directed Hausdorff distance is the maximum distance any point
+    /// on A can be from B:
+    /// </para>
+    /// <code>
+    /// h(A, B) = max_{a in A} min_{b in B} distance(a, b)
+    /// </code>
+    /// <para>
+    /// It is asymmetric. The symmetric Hausdorff distance is
+    /// <c>max(h(A, B), h(B, A))</c>.
+    /// </para>
+    /// <para>
+    /// Empty operands yield <see cref="double.NaN"/> and a null realizing pair.
+    /// A negative tolerance throws <see cref="ArgumentException"/>.
+    /// Zero tolerance is allowed (zero-size input).
+    /// </para>
+    /// <para>
+    /// This is the locus (continuous) algorithm from JTS 1.21 / #1182.
+    /// Do not confuse it with <see cref="DiscreteHausdorffDistance"/>, which
+    /// only samples vertices (optionally densified).
+    /// </para>
+    /// <para>
+    /// The class-comment formula in JTS that writes <c>max_a (max_b ...)</c>
+    /// is farthest-pair; the algorithm implemented here is max-min.
+    /// <see cref="FarthestPoints(Geometry)"/> keeps the JTS name but returns
+    /// the max-min realizing pair.
+    /// </para>
+    /// <para>
+    /// Mixed-dimension collections follow JTS: only
+    /// <c>Dimension == Point</c> routes to the point walker.
+    /// A collection of points and lines drops the points
+    /// (JTS TODO: handle mixed geoms with points).
+    /// </para>
+    /// </remarks>
     /// <author>Martin Davis</author>
-    public class DirectedHausdorffDistance
+    public sealed class DirectedHausdorffDistance
     {
         private const double EmptyDistance = double.NaN;
 
@@ -63,52 +55,44 @@ namespace NetTopologySuite.Algorithm.Distance
         private const double AutoToleranceFactor = 1.0e4;
 
         /// <summary>
-        /// Heuristic factor to improve performance of area interior farthest point computation.
-        /// The LargestEmptyCircle computation is much slower than the boundary one,
-        /// is unlikely to occur, and accuracy is less critical (and obvious).
+        /// Largest-empty-circle is slower than the boundary walk;
+        /// a coarser tolerance is used for area-interior farthest points.
         /// </summary>
         private const double AreaInteriorToleranceFactor = 20;
 
         /// <summary>
-        /// Tolerance factor for <see cref="IsFullyWithinDistance(Geometry, double)"/>.
-        /// A larger factor is used to increase accuracy. The operation will usually short-circuit,
-        /// so performance impact is low.
+        /// Larger factor for <see cref="IsFullyWithinDistance(Geometry, double)"/>.
+        /// The operation usually short-circuits, so the cost is low.
         /// </summary>
         private const double FullyWithinToleranceFactor = 10 * AutoToleranceFactor;
 
+        private readonly Geometry _target;
+        private readonly TargetDistance _targetDistance;
+
         /// <summary>
-        /// Computes the directed Hausdorff distance of a query geometry A from a target one B.
+        /// Computes the directed Hausdorff distance of query <paramref name="a"/>
+        /// from target <paramref name="b"/>.
         /// </summary>
-        /// <param name="a">The query geometry</param>
-        /// <param name="b">The target geometry</param>
-        /// <returns>The directed Hausdorff distance, or <c>NaN</c> if an input is empty</returns>
+        /// <returns>The directed Hausdorff distance, or NaN if an input is empty.</returns>
         public static double Distance(Geometry a, Geometry b)
         {
             var hd = new DirectedHausdorffDistance(b);
-            return Distance(hd.FarthestPoints(a));
+            return PairDistance(hd.FarthestPoints(a));
         }
 
         /// <summary>
-        /// Computes the directed Hausdorff distance of a query geometry A from a target one B,
-        /// up to a given distance accuracy.
+        /// Computes the directed Hausdorff distance up to a given accuracy.
         /// </summary>
-        /// <param name="a">The query geometry</param>
-        /// <param name="b">The target geometry</param>
-        /// <param name="tolerance">The accuracy distance tolerance</param>
-        /// <returns>The directed Hausdorff distance, or <c>NaN</c> if an input is empty</returns>
         public static double Distance(Geometry a, Geometry b, double tolerance)
         {
             var hd = new DirectedHausdorffDistance(b);
-            return Distance(hd.FarthestPoints(a, tolerance));
+            return PairDistance(hd.FarthestPoints(a, tolerance));
         }
 
         /// <summary>
-        /// Computes a pair of points which attain the directed Hausdorff distance
-        /// of a query geometry A from a target one B.
+        /// Computes a pair of points [ptA, ptB] attaining the directed Hausdorff distance.
         /// </summary>
-        /// <param name="a">The query geometry</param>
-        /// <param name="b">The target geometry</param>
-        /// <returns>A pair of points <c>[ptA, ptB]</c> demonstrating the distance, or <c>null</c> if an input is empty</returns>
+        /// <returns>The realizing pair, or <c>null</c> if an input is empty.</returns>
         public static Coordinate[] DistancePoints(Geometry a, Geometry b)
         {
             var dhd = new DirectedHausdorffDistance(b);
@@ -116,13 +100,8 @@ namespace NetTopologySuite.Algorithm.Distance
         }
 
         /// <summary>
-        /// Computes a pair of points which attain the directed Hausdorff distance
-        /// of a query geometry A from a target one B, up to a given distance accuracy.
+        /// Computes a realizing pair up to a given accuracy.
         /// </summary>
-        /// <param name="a">The query geometry</param>
-        /// <param name="b">The target geometry</param>
-        /// <param name="tolerance">The accuracy distance tolerance</param>
-        /// <returns>A pair of points <c>[ptA, ptB]</c> demonstrating the distance, or <c>null</c> if an input is empty</returns>
         public static Coordinate[] DistancePoints(Geometry a, Geometry b, double tolerance)
         {
             var dhd = new DirectedHausdorffDistance(b);
@@ -130,12 +109,9 @@ namespace NetTopologySuite.Algorithm.Distance
         }
 
         /// <summary>
-        /// Computes a pair of points which attain the symmetric Hausdorff distance between two geometries.
-        /// This is the maximum of the two directed Hausdorff distances.
+        /// Computes a pair of points attaining the symmetric Hausdorff distance.
+        /// Points are returned in A–B order.
         /// </summary>
-        /// <param name="a">A geometry</param>
-        /// <param name="b">A geometry</param>
-        /// <returns>A pair of points <c>[ptA, ptB]</c> demonstrating the Hausdorff distance, or <c>null</c> if an input is empty</returns>
         public static Coordinate[] HausdorffDistancePoints(Geometry a, Geometry b)
         {
             var hdAB = new DirectedHausdorffDistance(b);
@@ -143,30 +119,24 @@ namespace NetTopologySuite.Algorithm.Distance
             var hdBA = new DirectedHausdorffDistance(a);
             var ptsBA = hdBA.FarthestPoints(b);
 
-            //-- return points in A-B order
             var pts = ptsAB;
-            if (Distance(ptsBA) > Distance(ptsAB))
-            {
-                //-- reverse the BA points
+            if (PairDistance(ptsBA) > PairDistance(ptsAB))
                 pts = Pair(ptsBA[1], ptsBA[0]);
-            }
             return pts;
         }
 
         /// <summary>
-        /// Computes the symmetric Hausdorff distance between two geometries.
-        /// This is the maximum of the two directed Hausdorff distances.
+        /// Computes the symmetric Hausdorff distance
+        /// <c>max(h(A, B), h(B, A))</c>.
         /// </summary>
-        /// <param name="a">A geometry</param>
-        /// <param name="b">A geometry</param>
-        /// <returns>The Hausdorff distance, or <c>NaN</c> if an input is empty</returns>
         public static double HausdorffDistance(Geometry a, Geometry b)
         {
-            return Distance(HausdorffDistancePoints(a, b));
+            return PairDistance(HausdorffDistancePoints(a, b));
         }
 
         /// <summary>
-        /// Computes whether a query geometry lies fully within a given distance of a target geometry.
+        /// Tests whether query <paramref name="a"/> lies fully within
+        /// <paramref name="maxDistance"/> of target <paramref name="b"/>.
         /// </summary>
         public static bool IsFullyWithinDistance(Geometry a, Geometry b, double maxDistance)
         {
@@ -175,8 +145,7 @@ namespace NetTopologySuite.Algorithm.Distance
         }
 
         /// <summary>
-        /// Computes whether a query geometry lies fully within a given distance of a target geometry,
-        /// up to a given distance accuracy.
+        /// Tests full containment within a distance, up to a given accuracy.
         /// </summary>
         public static bool IsFullyWithinDistance(Geometry a, Geometry b, double maxDistance, double tolerance)
         {
@@ -184,7 +153,61 @@ namespace NetTopologySuite.Algorithm.Distance
             return hd.IsFullyWithinDistance(a, maxDistance, tolerance);
         }
 
-        private static double Distance(Coordinate[] pts)
+        /// <summary>
+        /// Creates a prepared instance that indexes the target once.
+        /// </summary>
+        /// <param name="geom">The geometry to compute the distance from.</param>
+        public DirectedHausdorffDistance(Geometry geom)
+        {
+            _target = geom;
+            _targetDistance = new TargetDistance(geom);
+        }
+
+        /// <summary>
+        /// Tests whether <paramref name="geom"/> lies fully within
+        /// <paramref name="maxDistance"/> of the prepared target.
+        /// </summary>
+        public bool IsFullyWithinDistance(Geometry geom, double maxDistance)
+        {
+            double tolerance = maxDistance / FullyWithinToleranceFactor;
+            return IsFullyWithinDistance(geom, maxDistance, tolerance);
+        }
+
+        /// <summary>
+        /// Tests full containment within a distance, up to a given accuracy.
+        /// Empty operands are not within any finite distance.
+        /// </summary>
+        public bool IsFullyWithinDistance(Geometry geom, double maxDistance, double tolerance)
+        {
+            if (geom.IsEmpty || _target.IsEmpty)
+                return false;
+            if (IsBeyond(geom.EnvelopeInternal, _target.EnvelopeInternal, maxDistance))
+                return false;
+
+            var maxDistCoords = ComputeDistancePoints(geom, tolerance, maxDistance);
+            if (maxDistCoords == null)
+                return false;
+            return PairDistance(maxDistCoords) <= maxDistance;
+        }
+
+        /// <summary>
+        /// Computes a pair of points attaining the directed Hausdorff distance
+        /// from <paramref name="geom"/> to the prepared target.
+        /// </summary>
+        public Coordinate[] FarthestPoints(Geometry geom)
+        {
+            return FarthestPoints(geom, ComputeTolerance(geom));
+        }
+
+        /// <summary>
+        /// Computes a realizing pair up to a given accuracy.
+        /// </summary>
+        public Coordinate[] FarthestPoints(Geometry geom, double tolerance)
+        {
+            return ComputeDistancePoints(geom, tolerance, -1.0);
+        }
+
+        private static double PairDistance(Coordinate[] pts)
         {
             if (pts == null)
                 return EmptyDistance;
@@ -201,103 +224,51 @@ namespace NetTopologySuite.Algorithm.Distance
             return geom.EnvelopeInternal.Diameter / AutoToleranceFactor;
         }
 
-        private readonly Geometry _target;
-        private readonly TargetDistance _targetDistance;
-
         /// <summary>
-        /// Create a new instance for a target geometry.
-        /// </summary>
-        /// <param name="geom">The geometry to compute the distance from</param>
-        public DirectedHausdorffDistance(Geometry geom)
-        {
-            _target = geom;
-            _targetDistance = new TargetDistance(_target);
-        }
-
-        /// <summary>
-        /// Tests whether a query geometry lies fully within a given distance of the target geometry.
-        /// </summary>
-        public bool IsFullyWithinDistance(Geometry geom, double maxDistance)
-        {
-            double tolerance = maxDistance / FullyWithinToleranceFactor;
-            return IsFullyWithinDistance(geom, maxDistance, tolerance);
-        }
-
-        /// <summary>
-        /// Tests whether a query geometry lies fully within a given distance of the target geometry,
-        /// up to a given distance accuracy.
-        /// </summary>
-        public bool IsFullyWithinDistance(Geometry geom, double maxDistance, double tolerance)
-        {
-            //-- envelope checks
-            if (IsBeyond(geom.EnvelopeInternal, _target.EnvelopeInternal, maxDistance))
-                return false;
-
-            var maxDistCoords = ComputeDistancePoints(geom, tolerance, maxDistance);
-            //-- handle empty case
-            if (maxDistCoords == null)
-                return false;
-            return Distance(maxDistCoords) <= maxDistance;
-        }
-
-        /// <summary>
-        /// Tests if an envelope must have a side farther than the maximum distance from another envelope.
+        /// Tests whether envelope A must have a side farther than
+        /// <paramref name="maxDistance"/> from envelope B.
+        /// Null (empty) envelopes are not beyond.
         /// </summary>
         private static bool IsBeyond(Envelope envA, Envelope envB, double maxDistance)
         {
+            if (envA.IsNull || envB.IsNull)
+                return false;
             return envA.MinX < envB.MinX - maxDistance
                 || envA.MinY < envB.MinY - maxDistance
                 || envA.MaxX > envB.MaxX + maxDistance
                 || envA.MaxY > envB.MaxY + maxDistance;
         }
 
-        /// <summary>
-        /// Computes a pair of points which attain the directed Hausdorff distance
-        /// of a query geometry A from the target B.
-        /// </summary>
-        public Coordinate[] FarthestPoints(Geometry geom)
-        {
-            double tolerance = ComputeTolerance(geom);
-            return FarthestPoints(geom, tolerance);
-        }
+        private static bool IsValidLimit(double limit) => limit >= 0.0;
 
-        /// <summary>
-        /// Computes a pair of points which attain the directed Hausdorff distance
-        /// of a query geometry A from the target B, up to a given distance accuracy.
-        /// </summary>
-        public Coordinate[] FarthestPoints(Geometry geom, double tolerance)
-        {
-            return ComputeDistancePoints(geom, tolerance, -1.0);
-        }
+        private static bool IsBeyondLimit(double maxDist, double maxDistanceLimit)
+            => maxDistanceLimit >= 0 && maxDist > maxDistanceLimit;
+
+        private static bool IsWithinLimit(double maxDist, double maxDistanceLimit)
+            => maxDistanceLimit >= 0 && maxDist <= maxDistanceLimit;
 
         private Coordinate[] ComputeDistancePoints(Geometry geom, double tolerance, double maxDistanceLimit)
         {
-            //-- Negative tolerances are not allowed.
-            //-- Zero tolerance is allowed, to support zero-size input.
             if (tolerance < 0.0)
                 throw new ArgumentException("Tolerance must be non-negative", nameof(tolerance));
 
             if (geom.IsEmpty || _target.IsEmpty)
                 return null;
 
-            if (geom.Dimension == Dimension.Point)
-            {
+            if (geom.Dimension == Dimension.P)
                 return ComputeForPoints(geom, maxDistanceLimit);
-            }
 
+            // TODO: handle mixed geoms with points (JTS)
             var maxDistPtsEdge = ComputeForEdges(geom, tolerance, maxDistanceLimit);
 
-            if (IsBeyondLimit(Distance(maxDistPtsEdge), maxDistanceLimit))
-            {
+            if (IsBeyondLimit(PairDistance(maxDistPtsEdge), maxDistanceLimit))
                 return maxDistPtsEdge;
-            }
 
-            //-- Polygonal query geometry may have an interior point as the farthest point.
-            if (geom.Dimension == Dimension.Surface)
+            if (geom.Dimension == Dimension.A)
             {
                 var maxDistPtsInterior = ComputeForAreaInterior(geom, tolerance);
                 if (maxDistPtsInterior != null
-                    && Distance(maxDistPtsInterior) > Distance(maxDistPtsEdge))
+                    && PairDistance(maxDistPtsInterior) > PairDistance(maxDistPtsEdge))
                 {
                     return maxDistPtsInterior;
                 }
@@ -309,10 +280,8 @@ namespace NetTopologySuite.Algorithm.Distance
         {
             double maxDist = -1.0;
             Coordinate[] maxDistPtsAB = null;
-            var geomi = new GeometryCollectionEnumerator(geom);
-            while (geomi.MoveNext())
+            foreach (var geomElem in new GeometryCollectionEnumerator(geom))
             {
-                var geomElem = geomi.Current;
                 if (!(geomElem is Point))
                     continue;
 
@@ -321,7 +290,6 @@ namespace NetTopologySuite.Algorithm.Distance
                 double dist = pA.Distance(pB);
 
                 bool isInterior = dist > 0 && _targetDistance.IsInterior(pA);
-                //-- check for interior point
                 if (isInterior)
                 {
                     dist = 0;
@@ -332,11 +300,8 @@ namespace NetTopologySuite.Algorithm.Distance
                     maxDist = dist;
                     maxDistPtsAB = Pair(pA, pB);
                 }
-                if (IsValidLimit(maxDistanceLimit)
-                    && IsBeyondLimit(maxDist, maxDistanceLimit))
-                {
+                if (IsValidLimit(maxDistanceLimit) && IsBeyondLimit(maxDist, maxDistanceLimit))
                     break;
-                }
             }
             return maxDistPtsAB;
         }
@@ -348,23 +313,13 @@ namespace NetTopologySuite.Algorithm.Distance
             DhdSegment segMaxDist = null;
             while (!segQueue.IsEmpty())
             {
-                // get the segment with greatest distance bound
                 var segMaxBound = segQueue.Poll();
-
-                //-- Save if segment point is farther than current farthest
-                if (segMaxDist == null
-                    || segMaxBound.MaxDistance > segMaxDist.MaxDistance)
-                {
+                if (segMaxDist == null || segMaxBound.MaxDistance > segMaxDist.MaxDistance)
                     segMaxDist = segMaxBound;
-                }
 
-                //-- Stop searching if remaining items must all be closer than current maximum.
                 if (segMaxBound.MaxDistanceBound <= segMaxDist.MaxDistance)
-                {
                     break;
-                }
 
-                //-- If maxDistanceLimit is specified, can stop searching in two cases.
                 if (IsValidLimit(maxDistanceLimit))
                 {
                     if (IsWithinLimit(segMaxBound.MaxDistanceBound, maxDistanceLimit)
@@ -374,17 +329,10 @@ namespace NetTopologySuite.Algorithm.Distance
                     }
                 }
 
-                //-- Equal-or-collinear segments don't need further bisection.
-                //-- This greatly improves performance when inputs are identical/collinear.
-                if (segMaxBound.MaxDistance == 0.0)
-                {
-                    if (IsSameOrCollinear(segMaxBound))
-                        continue;
-                }
+                if (segMaxBound.MaxDistance == 0.0 && IsSameOrCollinear(segMaxBound))
+                    continue;
 
-                //-- If segment is longer than tolerance, bisect and keep searching.
-                if (tolerance > 0
-                    && segMaxBound.Length > tolerance)
+                if (tolerance > 0 && segMaxBound.Length > tolerance)
                 {
                     var bisects = segMaxBound.Bisect(_targetDistance);
                     AddNonInterior(bisects[0], segQueue);
@@ -395,8 +343,6 @@ namespace NetTopologySuite.Algorithm.Distance
             if (segMaxDist != null)
                 return segMaxDist.GetMaxDistPts();
 
-            //-- No DHD segment was found: all were inside the target.
-            //-- In this case distance is zero. Return a single coordinate as a representative point.
             var maxPt = geom.Coordinate;
             return Pair(maxPt, maxPt);
         }
@@ -405,84 +351,44 @@ namespace NetTopologySuite.Algorithm.Distance
         {
             var f0 = _targetDistance.NearestLocation(seg.P0);
             var f1 = _targetDistance.NearestLocation(seg.P1);
-            return IsSameSegment(f0, f1);
+            return f0.IsSameSegment(f1);
         }
-
-        private static bool IsSameSegment(GeometryLocation a, GeometryLocation b)
-        {
-            if (a == null || b == null) return false;
-            return ReferenceEquals(a.GeometryComponent, b.GeometryComponent)
-                && a.SegmentIndex == b.SegmentIndex;
-        }
-
-        private static bool IsValidLimit(double limit) => limit >= 0.0;
-
-        private static bool IsBeyondLimit(double maxDist, double maxDistanceLimit)
-            => maxDistanceLimit >= 0 && maxDist > maxDistanceLimit;
-
-        private static bool IsWithinLimit(double maxDist, double maxDistanceLimit)
-            => maxDistanceLimit >= 0 && maxDist <= maxDistanceLimit;
 
         private void AddNonInterior(DhdSegment segment, PriorityQueue<DhdSegment> segQueue)
         {
-            //-- discard segment if it is interior to a polygon
             if (IsInterior(segment))
                 return;
-            //-- DhdSegment.CompareTo inverts ordering so Poll() returns the segment with greatest bound.
             segQueue.Add(segment);
         }
 
-        /// <summary>
-        /// Tests if segment is fully in the interior of the target geometry polygons (if any).
-        /// </summary>
         private bool IsInterior(DhdSegment segment)
         {
             if (segment.MaxDistance > 0.0)
                 return false;
-            return _targetDistance.IsInterior(segment.Endpoint(0), segment.Endpoint(1));
+            return _targetDistance.IsInterior(segment.GetEndpoint(0), segment.GetEndpoint(1));
         }
 
-        /// <summary>
-        /// If the query geometry is polygonal, it is possible the farthest point lies in its interior.
-        /// In this case it occurs at the centre of the Largest Empty Circle
-        /// with B as obstacles and the query geometry as constraint.
-        /// </summary>
         private Coordinate[] ComputeForAreaInterior(Geometry geom, double tolerance)
         {
             if (tolerance <= 0.0)
                 return null;
 
             var polygonal = geom;
-
-            //-- Optimization: skip if A interior cannot intersect B,
-            //-- so farthest point must lie on A boundary
             if (polygonal.EnvelopeInternal.Disjoint(_target.EnvelopeInternal))
                 return null;
 
-            var centerPt = LargestEmptyCircle.GetCenter(_target, polygonal,
-                tolerance * AreaInteriorToleranceFactor);
+            var centerPt = LargestEmptyCircle.GetCenter(_target, polygonal, tolerance * AreaInteriorToleranceFactor);
             var ptA = centerPt.Coordinate;
-            //-- If LEC centre is in B, the max distance is zero, so return null.
             if (_targetDistance.IsInterior(ptA))
                 return null;
             var ptB = _targetDistance.NearestFacetPoint(ptA);
             return Pair(ptA, ptB);
         }
 
-        /// <summary>
-        /// Creates the priority queue for segments. Segments which are interior to a polygonal
-        /// target geometry are not added to the queue.
-        /// </summary>
         private PriorityQueue<DhdSegment> CreateSegQueue(Geometry geom)
         {
             var priq = new PriorityQueue<DhdSegment>();
-            geom.Apply(new GeometryComponentFilter(g =>
-            {
-                if (g is LineString line)
-                {
-                    AddSegments(line.Coordinates, priq);
-                }
-            }));
+            geom.Apply(new SegmentCollector(this, priq));
             return priq;
         }
 
@@ -492,35 +398,38 @@ namespace NetTopologySuite.Algorithm.Distance
             DhdSegment prevSeg = null;
             for (int i = 0; i < pts.Length - 1; i++)
             {
-                DhdSegment seg;
-                if (i == 0)
-                {
-                    seg = DhdSegment.Create(pts[i], pts[i + 1], _targetDistance);
-                }
-                else
-                {
-                    //-- avoid recomputing prev point distance
-                    seg = DhdSegment.Create(prevSeg, pts[i + 1], _targetDistance);
-                }
+                var seg = i == 0
+                    ? DhdSegment.Create(pts[i], pts[i + 1], _targetDistance)
+                    : DhdSegment.Create(prevSeg, pts[i + 1], _targetDistance);
                 prevSeg = seg;
 
-                //-- don't add segment if it can't be further away than current max
-                if (segMaxDist == null
-                    || seg.MaxDistanceBound > segMaxDist.MaxDistance)
-                {
-                    //-- Don't add interior segments, since their distance must be zero.
+                if (segMaxDist == null || seg.MaxDistanceBound > segMaxDist.MaxDistance)
                     AddNonInterior(seg, priq);
-                }
 
-                if (segMaxDist == null
-                    || seg.MaxDistance > segMaxDist.MaxDistance)
-                {
+                if (segMaxDist == null || seg.MaxDistance > segMaxDist.MaxDistance)
                     segMaxDist = seg;
-                }
             }
         }
 
-        private class TargetDistance
+        private sealed class SegmentCollector : IGeometryComponentFilter
+        {
+            private readonly DirectedHausdorffDistance _owner;
+            private readonly PriorityQueue<DhdSegment> _priq;
+
+            public SegmentCollector(DirectedHausdorffDistance owner, PriorityQueue<DhdSegment> priq)
+            {
+                _owner = owner;
+                _priq = priq;
+            }
+
+            public void Filter(Geometry geom)
+            {
+                if (geom is LineString)
+                    _owner.AddSegments(geom.Coordinates, _priq);
+            }
+        }
+
+        private sealed class TargetDistance
         {
             private readonly IndexedFacetDistance _distanceToFacets;
             private readonly bool _isArea;
@@ -529,38 +438,28 @@ namespace NetTopologySuite.Algorithm.Distance
             public TargetDistance(Geometry geom)
             {
                 _distanceToFacets = new IndexedFacetDistance(geom);
-                _isArea = (int)geom.Dimension >= (int)Dimension.Surface;
+                _isArea = geom.Dimension >= Dimension.A;
                 if (_isArea)
-                {
                     _ptInArea = new IndexedPointInPolygonsLocator(geom);
-                }
             }
 
-            public GeometryLocation NearestLocation(Coordinate p)
-            {
-                return _distanceToFacets.NearestLocation(p);
-            }
+            public CoordinateSequenceLocation NearestLocation(Coordinate p)
+                => _distanceToFacets.NearestLocation(p);
 
             public Coordinate NearestFacetPoint(Coordinate p)
-            {
-                return _distanceToFacets.NearestPoint(p);
-            }
+                => _distanceToFacets.NearestPoint(p);
 
             public Coordinate NearestPoint(Coordinate p)
             {
-                if (_ptInArea != null)
-                {
-                    if (_ptInArea.Locate(p) != Location.Exterior)
-                    {
-                        return p;
-                    }
-                }
+                if (_ptInArea != null && _ptInArea.Locate(p) != Location.Exterior)
+                    return p;
                 return _distanceToFacets.NearestPoint(p);
             }
 
             public bool IsInterior(Coordinate p)
             {
-                if (!_isArea) return false;
+                if (!_isArea)
+                    return false;
                 return _ptInArea.Locate(p) == Location.Interior;
             }
 
@@ -568,18 +467,22 @@ namespace NetTopologySuite.Algorithm.Distance
             {
                 if (!_isArea)
                     return false;
-                //-- compute distance to B linework
                 double segDist = _distanceToFacets.Distance(p0, p1);
-                //-- if segment touches B linework it is not in interior
                 if (segDist == 0)
                     return false;
-                //-- only need to test one point to check interior
                 return IsInterior(p0);
             }
         }
 
-        private class DhdSegment : IComparable<DhdSegment>
+        private sealed class DhdSegment : IComparable<DhdSegment>
         {
+            internal readonly Coordinate P0;
+            internal readonly Coordinate P1;
+            private Coordinate _nearPt0;
+            private Coordinate _nearPt1;
+            private double _maxDistanceBound = double.NegativeInfinity;
+            private double _maxDistance;
+
             public static DhdSegment Create(Coordinate p0, Coordinate p1, TargetDistance dist)
             {
                 var seg = new DhdSegment(p0, p1);
@@ -593,13 +496,6 @@ namespace NetTopologySuite.Algorithm.Distance
                 seg.Init(prevSeg._nearPt1, dist);
                 return seg;
             }
-
-            public readonly Coordinate P0;
-            public readonly Coordinate P1;
-            private Coordinate _nearPt0;
-            private Coordinate _nearPt1;
-            private double _maxDistance;
-            private double _maxDistanceBound = double.NegativeInfinity;
 
             private DhdSegment(Coordinate p0, Coordinate p1)
             {
@@ -630,7 +526,7 @@ namespace NetTopologySuite.Algorithm.Distance
                 ComputeMaxDistances();
             }
 
-            public Coordinate Endpoint(int index) => index == 0 ? P0 : P1;
+            public Coordinate GetEndpoint(int index) => index == 0 ? P0 : P1;
 
             public double Length => P0.Distance(P1);
 
@@ -642,21 +538,14 @@ namespace NetTopologySuite.Algorithm.Distance
             {
                 double dist0 = P0.Distance(_nearPt0);
                 double dist1 = P1.Distance(_nearPt1);
-                if (dist0 > dist1)
-                    return new[] { P0.Copy(), _nearPt0.Copy() };
-                return new[] { P1.Copy(), _nearPt1.Copy() };
+                return dist0 > dist1 ? Pair(P0, _nearPt0) : Pair(P1, _nearPt1);
             }
 
-            /// <summary>
-            /// Computes a least upper bound for the maximum distance to a segment.
-            /// </summary>
             private void ComputeMaxDistances()
             {
-                //-- Least upper bound is the max distance to the endpoints,
-                //-- plus half segment length.
                 double dist0 = P0.Distance(_nearPt0);
                 double dist1 = P1.Distance(_nearPt1);
-                _maxDistance = System.Math.Max(dist0, dist1);
+                _maxDistance = Math.Max(dist0, dist1);
                 _maxDistanceBound = _maxDistance + Length / 2;
             }
 
@@ -667,19 +556,17 @@ namespace NetTopologySuite.Algorithm.Distance
                 return new[]
                 {
                     new DhdSegment(P0, _nearPt0, mid, nearPtMid),
-                    new DhdSegment(mid, nearPtMid, P1, _nearPt1),
+                    new DhdSegment(mid, nearPtMid, P1, _nearPt1)
                 };
             }
 
             /// <summary>
-            /// Inverts natural ordering so that <see cref="NetTopologySuite.Utilities.PriorityQueue{T}.Poll"/>
-            /// returns the segment with the greatest <see cref="MaxDistanceBound"/> first.
+            /// Invert so <see cref="PriorityQueue{T}.Poll"/> returns the largest bound.
             /// </summary>
             public int CompareTo(DhdSegment other)
-            {
-                if (other == null) return -1;
-                return -_maxDistanceBound.CompareTo(other._maxDistanceBound);
-            }
+                => -_maxDistanceBound.CompareTo(other._maxDistanceBound);
+
+            public override string ToString() => WKTWriter.ToLineString(P0, P1);
         }
     }
 }

--- a/src/NetTopologySuite/Operation/Distance/CoordinateSequenceLocation.cs
+++ b/src/NetTopologySuite/Operation/Distance/CoordinateSequenceLocation.cs
@@ -1,0 +1,76 @@
+using NetTopologySuite.Geometries;
+
+namespace NetTopologySuite.Operation.Distance
+{
+    /// <summary>
+    /// A location on a <see cref="FacetSequence"/> (JTS <c>CoordinateSequenceLocation</c>).
+    /// </summary>
+    /// <remarks>
+    /// Location indexes are always the index of a sequence segment,
+    /// so they are always less than the number of vertices.
+    /// The endpoint of a sequence uses the index of the final segment.
+    /// On a ring the index of the final endpoint is normalized to 0.
+    /// Used by <c>DirectedHausdorffDistance</c> to skip bisection of
+    /// identical or collinear zero-distance segments.
+    /// </remarks>
+    /// <author>Martin Davis</author>
+    public sealed class CoordinateSequenceLocation
+    {
+        private readonly CoordinateSequence _seq;
+        private readonly int _index;
+        private readonly Coordinate _pt;
+
+        /// <summary>
+        /// Creates a location on <paramref name="seq"/> at segment <paramref name="index"/>.
+        /// </summary>
+        public CoordinateSequenceLocation(CoordinateSequence seq, int index, Coordinate pt)
+        {
+            _seq = seq;
+            _pt = pt;
+            _index = index >= seq.Count ? seq.Count - 1 : index;
+        }
+
+        /// <summary>The coordinate of this location.</summary>
+        public Coordinate Coordinate => _pt;
+
+        /// <summary>The segment index of this location.</summary>
+        public int Index => _index;
+
+        /// <summary>
+        /// Tests whether two locations lie on the same target segment,
+        /// including the shared vertex of consecutive segments.
+        /// </summary>
+        public bool IsSameSegment(CoordinateSequenceLocation other)
+        {
+            if (!ReferenceEquals(_seq, other._seq))
+                return false;
+            if (_index == other._index)
+                return true;
+            if (IsNext(_index, other._index))
+            {
+                var endPt = _seq.GetCoordinate(_index + 1);
+                return other._pt.Equals2D(endPt);
+            }
+            if (IsNext(other._index, _index))
+            {
+                var endPt = _seq.GetCoordinate(_index + 1);
+                return _pt.Equals2D(endPt);
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// JTS <c>isNext</c> writes <c>index1 == 0 &amp;&amp; isRing &amp;&amp; index1 == size-1</c>,
+        /// which is unreachable. This is the documented ring intent
+        /// (last segment is adjacent to segment 0).
+        /// </summary>
+        private bool IsNext(int index, int index1)
+        {
+            if (index1 == index + 1)
+                return true;
+            if (CoordinateSequences.IsRing(_seq) && index1 == 0 && index + 1 == _seq.Count - 1)
+                return true;
+            return false;
+        }
+    }
+}

--- a/src/NetTopologySuite/Operation/Distance/FacetSequence.cs
+++ b/src/NetTopologySuite/Operation/Distance/FacetSequence.cs
@@ -171,6 +171,58 @@ namespace NetTopologySuite.Operation.Distance
             return locs;
         }
 
+        /// <summary>
+        /// Computes the nearest location on this facet sequence to a point
+        /// (JTS <c>FacetSequence.nearestLocation</c>).
+        /// </summary>
+        public CoordinateSequenceLocation NearestLocation(Coordinate p)
+        {
+            if (IsPoint)
+            {
+                return new CoordinateSequenceLocation(_pts, _start, _pts.GetCoordinate(_start));
+            }
+            return NearestLocationOnLine(p);
+        }
+
+        private CoordinateSequenceLocation NearestLocationOnLine(Coordinate pt)
+        {
+            double minDistance = double.MaxValue;
+            int index = _start;
+            Coordinate nearestPt = null;
+
+            for (int i = _start; i < _end - 1; i++)
+            {
+                var q0 = _pts.GetCoordinate(i);
+                var q1 = _pts.GetCoordinate(i + 1);
+                double dist = DistanceComputer.PointToSegment(pt, q0, q1);
+                if (dist < minDistance)
+                {
+                    minDistance = dist;
+                    var seg = new LineSegment(q0, q1);
+                    nearestPt = seg.ClosestPoint(pt);
+                    index = i;
+                    // segments are half-open: 2nd endpoint belongs to the next
+                    // segment except for the last segment of a non-closed sequence
+                    if (dist == 0.0 && pt.Equals2D(q1))
+                    {
+                        if (index < _pts.Count - 1)
+                            index++;
+                        index = NormalizeRingIndex(_pts, index);
+                    }
+                    if (minDistance <= 0.0)
+                        break;
+                }
+            }
+            return new CoordinateSequenceLocation(_pts, index, nearestPt);
+        }
+
+        private static int NormalizeRingIndex(CoordinateSequence pts, int index)
+        {
+            if (CoordinateSequences.IsRing(pts) && index >= pts.Count - 1)
+                return 0;
+            return index;
+        }
+
         private double ComputeDistanceLineLine(FacetSequence facetSeq, GeometryLocation[] locs)
         {
             // both linear - compute minimum segment-segment distance

--- a/src/NetTopologySuite/Operation/Distance/IndexedFacedDistance.cs
+++ b/src/NetTopologySuite/Operation/Distance/IndexedFacedDistance.cs
@@ -155,6 +155,49 @@ namespace NetTopologySuite.Operation.Distance
         }
 
         /// <summary>
+        /// Computes the distance from the base geometry to a single point.
+        /// </summary>
+        /// <param name="p">The query coordinate</param>
+        /// <returns>The distance to the nearest point on the base geometry</returns>
+        public double Distance(Coordinate p)
+        {
+            return Distance(_baseGeometry.Factory.CreatePoint(p));
+        }
+
+        /// <summary>
+        /// Computes the distance from the base geometry to a line segment defined by two points.
+        /// </summary>
+        /// <param name="p0">The first endpoint of the segment</param>
+        /// <param name="p1">The second endpoint of the segment</param>
+        /// <returns>The distance from the segment to the base geometry</returns>
+        public double Distance(Coordinate p0, Coordinate p1)
+        {
+            return Distance(_baseGeometry.Factory.CreateLineString(new[] { p0, p1 }));
+        }
+
+        /// <summary>
+        /// Computes the nearest point on the base geometry to a query coordinate.
+        /// </summary>
+        /// <param name="p">The query coordinate</param>
+        /// <returns>The nearest coordinate on the base geometry</returns>
+        public Coordinate NearestPoint(Coordinate p)
+        {
+            var pair = NearestPoints(_baseGeometry.Factory.CreatePoint(p));
+            return pair == null ? null : pair[0];
+        }
+
+        /// <summary>
+        /// Computes the nearest location on the base geometry to a query coordinate.
+        /// </summary>
+        /// <param name="p">The query coordinate</param>
+        /// <returns>The nearest <see cref="GeometryLocation"/> on the base geometry</returns>
+        public GeometryLocation NearestLocation(Coordinate p)
+        {
+            var locs = NearestLocations(_baseGeometry.Factory.CreatePoint(p));
+            return locs == null ? null : locs[0];
+        }
+
+        /// <summary>
         /// Tests whether the base geometry lies within
         /// a specified distance of the given geometry.
         /// </summary>

--- a/src/NetTopologySuite/Operation/Distance/IndexedFacedDistance.cs
+++ b/src/NetTopologySuite/Operation/Distance/IndexedFacedDistance.cs
@@ -1,4 +1,5 @@
 ﻿using NetTopologySuite.Geometries;
+using NetTopologySuite.Geometries.Implementation;
 using NetTopologySuite.Index.Strtree;
 
 namespace NetTopologySuite.Operation.Distance
@@ -146,55 +147,52 @@ namespace NetTopologySuite.Operation.Distance
             return nearestPts;
         }
 
+        /// <summary>
+        /// Computes the nearest location on the target geometry to a point
+        /// (JTS <c>IndexedFacetDistance.nearestLocation</c>).
+        /// </summary>
+        public CoordinateSequenceLocation NearestLocation(Coordinate p)
+        {
+            var seq = new CoordinateArraySequence(new[] { p });
+            var fs = new FacetSequence(seq, 0);
+            var fsN = _cachedTree.NearestNeighbour(fs.Envelope, fs, FacetSeqDist);
+            return fsN.NearestLocation(p);
+        }
+
+        /// <summary>
+        /// Computes the nearest point on the target geometry to a point.
+        /// </summary>
+        public Coordinate NearestPoint(Coordinate p)
+        {
+            return NearestLocation(p).Coordinate;
+        }
+
+        /// <summary>
+        /// Computes the distance from the target geometry to a point.
+        /// </summary>
+        public double Distance(Coordinate p)
+        {
+            return p.Distance(NearestPoint(p));
+        }
+
+        /// <summary>
+        /// Computes the distance from the target geometry to a segment.
+        /// </summary>
+        public double Distance(Coordinate p0, Coordinate p1)
+        {
+            var seq = new CoordinateArraySequence(new[] { p0, p1 });
+            var fs2 = new FacetSequence(seq, 0, 2);
+            var fs1 = _cachedTree.NearestNeighbour(fs2.Envelope, fs2, FacetSeqDist);
+            var loc = fs1.NearestLocations(fs2);
+            return loc[0].Coordinate.Distance(loc[1].Coordinate);
+        }
+
         private static Coordinate[] ToPoints(GeometryLocation[] locations)
         {
             if (locations == null)
                 return null;
             var nearestPts = new [] {locations[0].Coordinate, locations[1].Coordinate};
             return nearestPts;
-        }
-
-        /// <summary>
-        /// Computes the distance from the base geometry to a single point.
-        /// </summary>
-        /// <param name="p">The query coordinate</param>
-        /// <returns>The distance to the nearest point on the base geometry</returns>
-        public double Distance(Coordinate p)
-        {
-            return Distance(_baseGeometry.Factory.CreatePoint(p));
-        }
-
-        /// <summary>
-        /// Computes the distance from the base geometry to a line segment defined by two points.
-        /// </summary>
-        /// <param name="p0">The first endpoint of the segment</param>
-        /// <param name="p1">The second endpoint of the segment</param>
-        /// <returns>The distance from the segment to the base geometry</returns>
-        public double Distance(Coordinate p0, Coordinate p1)
-        {
-            return Distance(_baseGeometry.Factory.CreateLineString(new[] { p0, p1 }));
-        }
-
-        /// <summary>
-        /// Computes the nearest point on the base geometry to a query coordinate.
-        /// </summary>
-        /// <param name="p">The query coordinate</param>
-        /// <returns>The nearest coordinate on the base geometry</returns>
-        public Coordinate NearestPoint(Coordinate p)
-        {
-            var pair = NearestPoints(_baseGeometry.Factory.CreatePoint(p));
-            return pair == null ? null : pair[0];
-        }
-
-        /// <summary>
-        /// Computes the nearest location on the base geometry to a query coordinate.
-        /// </summary>
-        /// <param name="p">The query coordinate</param>
-        /// <returns>The nearest <see cref="GeometryLocation"/> on the base geometry</returns>
-        public GeometryLocation NearestLocation(Coordinate p)
-        {
-            var locs = NearestLocations(_baseGeometry.Factory.CreatePoint(p));
-            return locs == null ? null : locs[0];
         }
 
         /// <summary>

--- a/test/NetTopologySuite.TestRunner/Functions/DistanceFunctions.cs
+++ b/test/NetTopologySuite.TestRunner/Functions/DistanceFunctions.cs
@@ -56,6 +56,33 @@ namespace Open.Topology.TestRunner.Functions
             return dist.OrientedDistance();
         }
 
+        /// <summary>
+        /// Locus directed Hausdorff distance h(A, B). Distinct from
+        /// <see cref="DiscreteHausdorffDistance"/>.
+        /// </summary>
+        public static double DirectedHausdorffDistance(Geometry a, Geometry b)
+        {
+            return NetTopologySuite.Algorithm.Distance.DirectedHausdorffDistance.Distance(a, b);
+        }
+
+        /// <summary>
+        /// Realizing segment for <see cref="DirectedHausdorffDistance(Geometry, Geometry)"/>.
+        /// </summary>
+        public static Geometry DirectedHausdorffLine(Geometry a, Geometry b)
+        {
+            var pts = NetTopologySuite.Algorithm.Distance.DirectedHausdorffDistance.DistancePoints(a, b);
+            return pts == null ? a.Factory.CreateLineString() : a.Factory.CreateLineString(pts);
+        }
+
+        /// <summary>
+        /// Realizing segment for the symmetric Hausdorff distance.
+        /// </summary>
+        public static Geometry HausdorffLine(Geometry a, Geometry b)
+        {
+            var pts = NetTopologySuite.Algorithm.Distance.DirectedHausdorffDistance.HausdorffDistancePoints(a, b);
+            return pts == null ? a.Factory.CreateLineString() : a.Factory.CreateLineString(pts);
+        }
+
         public static double DistanceIndexed(Geometry a, Geometry b)
         {
             return IndexedFacetDistance.Distance(a, b);

--- a/test/NetTopologySuite.Tests.NUnit/Algorithm/Distance/DirectedHausdorffDistanceTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Algorithm/Distance/DirectedHausdorffDistanceTest.cs
@@ -1,0 +1,445 @@
+using System;
+using NetTopologySuite.Algorithm.Distance;
+using NetTopologySuite.Geometries;
+using NUnit.Framework;
+
+namespace NetTopologySuite.Tests.NUnit.Algorithm.Distance
+{
+    public class DirectedHausdorffDistanceTest : GeometryTestCase
+    {
+        private const double Tolerance = 0.001;
+
+        //-- empty inputs
+
+        [Test]
+        public void TestEmptyPoint() => CheckDistanceEmpty("POINT EMPTY", "POINT (1 1)");
+
+        [Test]
+        public void TestEmptyLine() => CheckDistanceEmpty("LINESTRING EMPTY", "LINESTRING (0 0, 2 1)");
+
+        [Test]
+        public void TestEmptyPolygon() => CheckDistanceEmpty("POLYGON EMPTY", "POLYGON ((1 9, 9 9, 9 1, 1 1, 1 9))");
+
+        //-- extreme and invalid inputs
+
+        [Test]
+        public void TestZeroTolerancePoint()
+        {
+            CheckDistance("POINT (5 5)", "LINESTRING (5 1, 9 5)", 0, "LINESTRING (5 5, 7 3)");
+        }
+
+        [Test]
+        public void TestZeroToleranceLine()
+        {
+            CheckDistance("LINESTRING (1 5, 5 5)", "LINESTRING (5 1, 9 5)", 0, "LINESTRING (1 5, 5 1)");
+        }
+
+        [Test]
+        public void TestZeroToleranceZeroLengthLineQuery()
+        {
+            CheckDistance("LINESTRING (5 5, 5 5)", "LINESTRING (5 1, 9 5)", 0, "LINESTRING (5 5, 7 3)");
+        }
+
+        [Test]
+        public void TestZeroLengthLineQuery()
+        {
+            CheckDistance("LINESTRING (5 5, 5 5)", "LINESTRING (5 1, 9 5)", "LINESTRING (5 5, 7 3)");
+        }
+
+        [Test]
+        public void TestZeroLengthPolygonQuery()
+        {
+            CheckDistance("POLYGON ((5 5, 5 5, 5 5, 5 5))", "LINESTRING (5 1, 9 5)", "LINESTRING (5 5, 7 3)");
+        }
+
+        [Test]
+        public void TestZeroLengthLineTarget()
+        {
+            CheckDistance("POINT (5 5)", "LINESTRING (5 1, 5 1)", "LINESTRING (5 5, 5 1)");
+        }
+
+        [Test]
+        public void TestNegativeTolerancePoint()
+        {
+            Assert.Throws<ArgumentException>(() =>
+                CheckDistance("POINT (5 5)", "LINESTRING (5 1, 9 5)", -1, "LINESTRING (5 5, 7 3)"));
+        }
+
+        [Test]
+        public void TestNegativeToleranceLine()
+        {
+            Assert.Throws<ArgumentException>(() =>
+                CheckDistance("LINESTRING (1 5, 5 5)", "LINESTRING (5 1, 9 5)", -1, "LINESTRING (1 5, 5 1)"));
+        }
+
+        //--------------------------------------
+
+        [Test]
+        public void TestPointPoint()
+        {
+            CheckHausdorff("POINT (0 0)", "POINT (1 1)", "LINESTRING (0 0, 1 1)");
+        }
+
+        [Test]
+        public void TestPointsPoints()
+        {
+            string a = "MULTIPOINT ((0 1), (2 3), (4 5), (6 6))";
+            string b = "MULTIPOINT ((0.1 0), (1 0), (2 0), (3 0), (4 0), (5 0))";
+            CheckDistance(a, b, "LINESTRING (6 6, 5 0)");
+            CheckDistance(b, a, "LINESTRING (5 0, 2 3)");
+            CheckHausdorff(a, b, "LINESTRING (6 6, 5 0)");
+        }
+
+        [Test]
+        public void TestPointPolygonInterior()
+        {
+            CheckDistance("POINT (3 4)", "POLYGON ((1 9, 9 9, 9 1, 1 1, 1 9))", 0);
+        }
+
+        [Test]
+        public void TestPointsPolygon()
+        {
+            CheckDistance("MULTIPOINT ((4 3), (2 8), (8 5))", "POLYGON ((6 9, 6 4, 9 1, 1 1, 6 9))",
+                "LINESTRING (2 8, 4.426966292134832 6.48314606741573)");
+        }
+
+        [Test]
+        public void TestLineSegments()
+        {
+            CheckHausdorff("LINESTRING (0 0, 2 0)", "LINESTRING (0 0, 2 1)", "LINESTRING (2 0, 2 1)");
+        }
+
+        [Test]
+        public void TestLineSegments2()
+        {
+            CheckHausdorff("LINESTRING (0 0, 2 0)", "LINESTRING (0 1, 1 2, 2 1)", "LINESTRING (1 0, 1 2)");
+        }
+
+        [Test]
+        public void TestLinePoints()
+        {
+            CheckHausdorff("LINESTRING (0 0, 2 0)", "MULTIPOINT (0 2, 1 0, 2 1)", "LINESTRING (0 0, 0 2)");
+        }
+
+        [Test]
+        public void TestLinesTopoEqual()
+        {
+            CheckDistance("MULTILINESTRING ((10 10, 10 90, 40 30), (40 30, 60 80, 90 30, 40 10))",
+                "LINESTRING (10 10, 10 90, 40 30, 60 80, 90 30, 40 10)",
+                0.0);
+        }
+
+        [Test]
+        public void TestLinesPolygon()
+        {
+            CheckHausdorff("MULTILINESTRING ((1 1, 2 7), (7 1, 9 9))",
+                "POLYGON ((3 7, 6 7, 6 4, 3 4, 3 7))",
+                "LINESTRING (9 9, 6 7)");
+        }
+
+        [Test]
+        public void TestLinesPolygon2()
+        {
+            string a = "MULTILINESTRING ((2 3, 2 7), (9 1, 9 8, 4 9))";
+            string b = "POLYGON ((3 7, 6 8, 8 2, 3 4, 3 7))";
+            CheckDistance(a, b, "LINESTRING (9 8, 6.3 7.1)");
+            // Symmetric Hausdorff: a's nearest-to-LEC-of-b vertex is a tie between (2,3) and (9,3),
+            // both at distance 3.5 from (5.5, 3). JTS's R-tree visits (2,3) first; NTS's reaches
+            // (9,3) first. The Hausdorff distance value is identical; check that instead.
+            CheckHausdorffDistanceValue(a, b, 3.5);
+        }
+
+        [Test]
+        public void TestPolygonLineCrossingBoundaryResult()
+        {
+            CheckDistance("POLYGON ((2 8, 8 2, 2 1, 2 8))",
+                "LINESTRING (6 5, 4 7, 0 0, 8 4)",
+                "LINESTRING (2 8, 3.9384615384615387 6.892307692307693)");
+        }
+
+        [Test]
+        public void TestPolygonLineCrossingInteriorPoint()
+        {
+            CheckDistanceStartPtLen("POLYGON ((2 8, 8 2, 2 1, 2 8))",
+                "LINESTRING (6 5, 4 7, 0 0, 9 1)",
+                "LINESTRING (4.555 2.989, 4.828 0.536)", 0.01);
+        }
+
+        [Test]
+        public void TestPolygonPolygon()
+        {
+            string a = "POLYGON ((2 18, 18 18, 17 3, 2 2, 2 18))";
+            string b = "POLYGON ((1 19, 5 12, 5 3, 14 10, 11 19, 19 19, 20 0, 1 1, 1 19))";
+            CheckDistance(b, a, "LINESTRING (20 0, 17 3)");
+            CheckDistance(a, b, "LINESTRING (6.6796875 18, 11 19)");
+            CheckHausdorff(a, b, "LINESTRING (6.6796875 18, 11 19)");
+        }
+
+        [Test]
+        public void TestPolygonPolygonHolesNested()
+        {
+            // B is contained in A
+            string a = "POLYGON ((1 19, 19 19, 19 1, 1 1, 1 19), (6 8, 11 14, 15 7, 6 8))";
+            string b = "POLYGON ((2 18, 18 18, 18 2, 2 2, 2 18), (10 17, 3 7, 17 5, 10 17))";
+            CheckDistance(a, b, "LINESTRING (9.817138671875 12.58056640625, 7.863620425230705 13.948029178901006)");
+            CheckDistance(b, a, 0.0);
+        }
+
+        [Test]
+        public void TestMultiPolygons()
+        {
+            string a = "MULTIPOLYGON (((1 1, 1 10, 5 1, 1 1)), ((4 17, 9 15, 9 6, 4 17)))";
+            string b = "MULTIPOLYGON (((1 12, 4 13, 8 10, 1 12)), ((3 8, 7 7, 6 2, 3 8)))";
+            CheckDistance(a, b, "LINESTRING (1 1, 5.4 3.2)");
+            CheckDistanceStartPtLen(b, a,
+                "LINESTRING (2.669921875 12.556640625, 5.446115154109589 13.818546660958905)",
+                0.01);
+        }
+
+        // Tests that target area interiors have distance = 0
+        [Test]
+        public void TestLinePolygonCrossing()
+        {
+            CheckDistance("LINESTRING (2 5, 5 10, 6 4)",
+                "POLYGON ((1 9, 9 9, 9 1, 1 1, 1 9))",
+                "LINESTRING (5 10, 5 9)");
+        }
+
+        [Test]
+        public void TestNonVertexResult()
+        {
+            string wkt1 = "LINESTRING (1 1, 5 10, 9 1)";
+            string wkt2 = "LINESTRING (0 10, 0 0, 10 0)";
+            CheckHausdorff(wkt1, wkt2, "LINESTRING (6.53857421875 6.5382080078125, 6.53857421875 0)");
+            CheckDistance(wkt1, wkt2, "LINESTRING (6.53857421875 6.5382080078125, 6.53857421875 0)");
+        }
+
+        [Test]
+        public void TestDirectedLines()
+        {
+            string wkt1 = "LINESTRING (1 6, 3 5, 1 4)";
+            string wkt2 = "LINESTRING (1 10, 9 5, 1 2)";
+            CheckDistance(wkt1, wkt2, "LINESTRING (1 6, 2.797752808988764 8.876404494382022)");
+            CheckDistance(wkt2, wkt1, "LINESTRING (9 5, 3 5)");
+        }
+
+        [Test]
+        public void TestDirectedLines2()
+        {
+            string wkt1 = "LINESTRING (1 6, 3 5, 1 4)";
+            string wkt2 = "LINESTRING (1 3, 1 9, 9 5, 1 1)";
+            CheckDistance(wkt1, wkt2, "LINESTRING (3 5, 1 5)");
+            CheckDistance(wkt2, wkt1, "LINESTRING (9 5, 3 5)");
+        }
+
+        // Tests that segments are detected as interior even for a large tolerance.
+        [Test]
+        public void TestInteriorSegmentsLargeTol()
+        {
+            string a = "POLYGON ((4 6, 5 6, 5 5, 4 5, 4 6))";
+            string b = "POLYGON ((1 9, 9 9, 9 1, 1 1, 1 9))";
+            CheckDistance(a, b, 2.0, 0.0);
+        }
+
+        // Tests that segment endpoint nearest points which are interior to B have distance 0
+        [Test]
+        public void TestInteriorSegmentsSameExterior()
+        {
+            string a = "POLYGON ((1 9, 3 9, 4 5, 5.05 9, 9 9, 9 1, 1 1, 1 9))";
+            string b = "POLYGON ((1 9, 9 9, 9 1, 1 1, 1 9))";
+            CheckDistance(a, b, 0.0);
+        }
+
+        //-----------------------------------------------------
+
+        [Test]
+        public void TestFullyWithinDistanceEmptyPoints()
+        {
+            CheckFullyWithinDistanceEmpty("POINT EMPTY", "MULTIPOINT ((1 1), (9 9))");
+        }
+
+        [Test]
+        public void TestFullyWithinDistanceEmptyLine()
+        {
+            CheckFullyWithinDistanceEmpty("LINESTRING EMPTY", "LINESTRING (9 9, 1 1)");
+        }
+
+        [Test]
+        public void TestFullyWithinDistancePoints()
+        {
+            string a = "MULTIPOINT ((1 9), (9 1))";
+            string b = "MULTIPOINT ((1 1), (9 9))";
+            CheckFullyWithinDistance(a, b, 1, false);
+            CheckFullyWithinDistance(a, b, 8.1, true);
+        }
+
+        [Test]
+        public void TestFullyWithinDistanceDisconnectedLines()
+        {
+            string a = "MULTILINESTRING ((1 9, 2 9), (8 1, 9 1))";
+            string b = "LINESTRING (9 9, 1 1)";
+            CheckFullyWithinDistance(a, b, 1, false);
+            CheckFullyWithinDistance(a, b, 6, true);
+            CheckFullyWithinDistance(b, a, 1, false);
+            CheckFullyWithinDistance(b, a, 7.1, true);
+        }
+
+        [Test]
+        public void TestFullyWithinDistanceDisconnectedPolygons()
+        {
+            string a = "MULTIPOLYGON (((1 9, 2 9, 2 8, 1 8, 1 9)), ((8 2, 9 2, 9 1, 8 1, 8 2)))";
+            string b = "POLYGON ((1 2, 9 9, 2 1, 1 2))";
+            CheckFullyWithinDistance(a, b, 1, false);
+            CheckFullyWithinDistance(a, b, 5.3, true);
+            CheckFullyWithinDistance(b, a, 1, false);
+            CheckFullyWithinDistance(b, a, 7.1, true);
+        }
+
+        [Test]
+        public void TestFullyWithinDistanceLines()
+        {
+            string a = "MULTILINESTRING ((1 1, 3 3), (7 7, 9 9))";
+            string b = "MULTILINESTRING ((1 9, 1 5), (6 4, 8 2))";
+            CheckFullyWithinDistance(a, b, 1, false);
+            CheckFullyWithinDistance(a, b, 4, false);
+            CheckFullyWithinDistance(a, b, 6, true);
+        }
+
+        [Test]
+        public void TestFullyWithinDistancePolygons()
+        {
+            string a = "POLYGON ((1 4, 4 4, 4 1, 1 1, 1 4))";
+            string b = "POLYGON ((10 10, 10 15, 15 15, 15 10, 10 10))";
+            CheckFullyWithinDistance(a, b, 5, false);
+            CheckFullyWithinDistance(a, b, 10, false);
+            CheckFullyWithinDistance(a, b, 20, true);
+        }
+
+        [Test]
+        public void TestFullyWithinDistancePolygonsNestedWithHole()
+        {
+            string a = "POLYGON ((2 8, 8 8, 8 2, 2 2, 2 8))";
+            string b = "POLYGON ((1 9, 9 9, 9 1, 1 1, 1 9), (3 7, 7 7, 7 3, 3 3, 3 7))";
+            CheckFullyWithinDistance(a, b, 1, false);
+            CheckFullyWithinDistance(a, b, 2, true);
+            CheckFullyWithinDistance(a, b, 3, true);
+        }
+
+        //======================================================================
+
+        private void CheckHausdorff(string wkt1, string wkt2, string wktExpected)
+        {
+            var g1 = Read(wkt1);
+            var g2 = Read(wkt2);
+            var pts = DirectedHausdorffDistance.HausdorffDistancePoints(g1, g2);
+            var result = g1.Factory.CreateLineString(pts);
+            var expected = Read(wktExpected);
+            CheckEqualResult(expected, result);
+        }
+
+        private void CheckDistance(string wkt1, string wkt2, string wktExpected)
+        {
+            var g1 = Read(wkt1);
+            var g2 = Read(wkt2);
+            var pts = DirectedHausdorffDistance.DistancePoints(g1, g2);
+            var result = g1.Factory.CreateLineString(pts);
+            var expected = Read(wktExpected);
+            CheckEqualResult(expected, result);
+        }
+
+        private void CheckDistance(string wkt1, string wkt2, double tolerance, string wktExpected)
+        {
+            var g1 = Read(wkt1);
+            var g2 = Read(wkt2);
+            var pts = DirectedHausdorffDistance.DistancePoints(g1, g2, tolerance);
+            var result = g1.Factory.CreateLineString(pts);
+            var expected = Read(wktExpected);
+            CheckEqualResult(expected, result);
+        }
+
+        private void CheckDistanceStartPtLen(string wkt1, string wkt2,
+            string wktExpected, double resultTolerance)
+        {
+            var g1 = Read(wkt1);
+            var g2 = Read(wkt2);
+            var pts = DirectedHausdorffDistance.DistancePoints(g1, g2);
+            var result = g1.Factory.CreateLineString(pts);
+            var expected = Read(wktExpected);
+
+            var resultPt = result.Coordinates[0];
+            var expectedPt = expected.Coordinates[0];
+            CheckEqualXY(expectedPt, resultPt, resultTolerance);
+
+            double distResult = result.Length;
+            double distExpected = expected.Length;
+            Assert.That(distResult, Is.EqualTo(distExpected).Within(resultTolerance));
+        }
+
+        private void CheckDistance(string wkt1, string wkt2, double tolerance, double expectedDistance)
+        {
+            var g1 = Read(wkt1);
+            var g2 = Read(wkt2);
+            double distResult = DirectedHausdorffDistance.Distance(g1, g2, tolerance);
+            Assert.That(distResult, Is.EqualTo(expectedDistance).Within(Tolerance));
+        }
+
+        private void CheckDistance(string wkt1, string wkt2, double expectedDistance)
+        {
+            var g1 = Read(wkt1);
+            var g2 = Read(wkt2);
+            double distResult = DirectedHausdorffDistance.Distance(g1, g2);
+            Assert.That(distResult, Is.EqualTo(expectedDistance).Within(Tolerance));
+        }
+
+        private void CheckFullyWithinDistance(string a, string b, double distance, bool expected)
+        {
+            var g1 = Read(a);
+            var g2 = Read(b);
+            bool result = DirectedHausdorffDistance.IsFullyWithinDistance(g1, g2, distance);
+            Assert.That(result, Is.EqualTo(expected));
+        }
+
+        private void CheckFullyWithinDistanceEmpty(string a, string b)
+        {
+            CheckFullyWithinDistance(a, b, 0, false);
+            CheckFullyWithinDistance(b, a, 0, false);
+            CheckFullyWithinDistance(a, b, 1, false);
+            CheckFullyWithinDistance(b, a, 1, false);
+            CheckFullyWithinDistance(a, b, 1000, false);
+            CheckFullyWithinDistance(b, a, 1000, false);
+        }
+
+        private void CheckDistanceEmpty(string a, string b)
+        {
+            var g1 = Read(a);
+            var g2 = Read(b);
+
+            var resultPts = DirectedHausdorffDistance.DistancePoints(g1, g2);
+            Assert.That(resultPts, Is.Null);
+
+            double resultDist = DirectedHausdorffDistance.Distance(g1, g2);
+            Assert.That(double.IsNaN(resultDist), Is.True);
+
+            double hausdorffDist = DirectedHausdorffDistance.HausdorffDistance(g1, g2);
+            Assert.That(double.IsNaN(hausdorffDist), Is.True);
+        }
+
+        private void CheckHausdorffDistanceValue(string wkt1, string wkt2, double expectedDistance)
+        {
+            var g1 = Read(wkt1);
+            var g2 = Read(wkt2);
+            double distResult = DirectedHausdorffDistance.HausdorffDistance(g1, g2);
+            Assert.That(distResult, Is.EqualTo(expectedDistance).Within(Tolerance));
+        }
+
+        private void CheckEqualResult(Geometry expected, Geometry actual)
+        {
+            bool equal = actual.EqualsExact(expected, Tolerance);
+            if (!equal)
+            {
+                TestContext.WriteLine($"FAIL:\nExpected = {expected}\nActual   = {actual}");
+            }
+            Assert.That(equal, Is.True);
+        }
+    }
+}

--- a/test/NetTopologySuite.Tests.NUnit/Algorithm/Distance/DirectedHausdorffDistanceTest.cs
+++ b/test/NetTopologySuite.Tests.NUnit/Algorithm/Distance/DirectedHausdorffDistanceTest.cs
@@ -1,90 +1,107 @@
 using System;
 using NetTopologySuite.Algorithm.Distance;
 using NetTopologySuite.Geometries;
+using NetTopologySuite.Tests.NUnit.Utilities;
 using NUnit.Framework;
 
 namespace NetTopologySuite.Tests.NUnit.Algorithm.Distance
 {
-    public class DirectedHausdorffDistanceTest : GeometryTestCase
+    /// <summary>
+    /// Port of JTS DirectedHausdorffDistanceTest (locationtech/jts#1182)
+    /// plus the discrete-under-estimate witness from DiscreteHausdorffDistance.
+    /// </summary>
+    public class DirectedHausdorffDistanceTest
     {
         private const double Tolerance = 0.001;
 
-        //-- empty inputs
+        [Test]
+        public void TestEmptyPoint()
+        {
+            CheckDistanceEmpty("POINT EMPTY", "POINT (1 1)");
+        }
 
         [Test]
-        public void TestEmptyPoint() => CheckDistanceEmpty("POINT EMPTY", "POINT (1 1)");
+        public void TestEmptyLine()
+        {
+            CheckDistanceEmpty("LINESTRING EMPTY", "LINESTRING (0 0, 2 1)");
+        }
 
         [Test]
-        public void TestEmptyLine() => CheckDistanceEmpty("LINESTRING EMPTY", "LINESTRING (0 0, 2 1)");
-
-        [Test]
-        public void TestEmptyPolygon() => CheckDistanceEmpty("POLYGON EMPTY", "POLYGON ((1 9, 9 9, 9 1, 1 1, 1 9))");
-
-        //-- extreme and invalid inputs
+        public void TestEmptyPolygon()
+        {
+            CheckDistanceEmpty("POLYGON EMPTY", "POLYGON ((1 9, 9 9, 9 1, 1 1, 1 9))");
+        }
 
         [Test]
         public void TestZeroTolerancePoint()
         {
-            CheckDistance("POINT (5 5)", "LINESTRING (5 1, 9 5)", 0, "LINESTRING (5 5, 7 3)");
+            CheckDistance("POINT (5 5)", "LINESTRING (5 1, 9 5)",
+                0, "LINESTRING (5 5, 7 3)");
         }
 
         [Test]
         public void TestZeroToleranceLine()
         {
-            CheckDistance("LINESTRING (1 5, 5 5)", "LINESTRING (5 1, 9 5)", 0, "LINESTRING (1 5, 5 1)");
+            CheckDistance("LINESTRING (1 5, 5 5)", "LINESTRING (5 1, 9 5)",
+                0, "LINESTRING (1 5, 5 1)");
         }
 
         [Test]
         public void TestZeroToleranceZeroLengthLineQuery()
         {
-            CheckDistance("LINESTRING (5 5, 5 5)", "LINESTRING (5 1, 9 5)", 0, "LINESTRING (5 5, 7 3)");
+            CheckDistance("LINESTRING (5 5, 5 5)", "LINESTRING (5 1, 9 5)",
+                0, "LINESTRING (5 5, 7 3)");
         }
 
         [Test]
         public void TestZeroLengthLineQuery()
         {
-            CheckDistance("LINESTRING (5 5, 5 5)", "LINESTRING (5 1, 9 5)", "LINESTRING (5 5, 7 3)");
+            CheckDistance("LINESTRING (5 5, 5 5)", "LINESTRING (5 1, 9 5)",
+                "LINESTRING (5 5, 7 3)");
         }
 
         [Test]
         public void TestZeroLengthPolygonQuery()
         {
-            CheckDistance("POLYGON ((5 5, 5 5, 5 5, 5 5))", "LINESTRING (5 1, 9 5)", "LINESTRING (5 5, 7 3)");
+            CheckDistance("POLYGON ((5 5, 5 5, 5 5, 5 5))", "LINESTRING (5 1, 9 5)",
+                "LINESTRING (5 5, 7 3)");
         }
 
         [Test]
         public void TestZeroLengthLineTarget()
         {
-            CheckDistance("POINT (5 5)", "LINESTRING (5 1, 5 1)", "LINESTRING (5 5, 5 1)");
+            CheckDistance("POINT (5 5)", "LINESTRING (5 1, 5 1)",
+                "LINESTRING (5 5, 5 1)");
         }
 
         [Test]
         public void TestNegativeTolerancePoint()
         {
             Assert.Throws<ArgumentException>(() =>
-                CheckDistance("POINT (5 5)", "LINESTRING (5 1, 9 5)", -1, "LINESTRING (5 5, 7 3)"));
+                CheckDistance("POINT (5 5)", "LINESTRING (5 1, 9 5)",
+                    -1, "LINESTRING (5 5, 7 3)"));
         }
 
         [Test]
         public void TestNegativeToleranceLine()
         {
             Assert.Throws<ArgumentException>(() =>
-                CheckDistance("LINESTRING (1 5, 5 5)", "LINESTRING (5 1, 9 5)", -1, "LINESTRING (1 5, 5 1)"));
+                CheckDistance("LINESTRING (1 5, 5 5)", "LINESTRING (5 1, 9 5)",
+                    -1, "LINESTRING (1 5, 5 1)"));
         }
-
-        //--------------------------------------
 
         [Test]
         public void TestPointPoint()
         {
-            CheckHausdorff("POINT (0 0)", "POINT (1 1)", "LINESTRING (0 0, 1 1)");
+            CheckHausdorff("POINT (0 0)", "POINT (1 1)",
+                "LINESTRING (0 0, 1 1)");
         }
 
         [Test]
         public void TestPointsPoints()
         {
-            string a = "MULTIPOINT ((0 1), (2 3), (4 5), (6 6))";
-            string b = "MULTIPOINT ((0.1 0), (1 0), (2 0), (3 0), (4 0), (5 0))";
+            const string a = "MULTIPOINT ((0 1), (2 3), (4 5), (6 6))";
+            const string b = "MULTIPOINT ((0.1 0), (1 0), (2 0), (3 0), (4 0), (5 0))";
             CheckDistance(a, b, "LINESTRING (6 6, 5 0)");
             CheckDistance(b, a, "LINESTRING (5 0, 2 3)");
             CheckHausdorff(a, b, "LINESTRING (6 6, 5 0)");
@@ -106,25 +123,29 @@ namespace NetTopologySuite.Tests.NUnit.Algorithm.Distance
         [Test]
         public void TestLineSegments()
         {
-            CheckHausdorff("LINESTRING (0 0, 2 0)", "LINESTRING (0 0, 2 1)", "LINESTRING (2 0, 2 1)");
+            CheckHausdorff("LINESTRING (0 0, 2 0)", "LINESTRING (0 0, 2 1)",
+                "LINESTRING (2 0, 2 1)");
         }
 
         [Test]
         public void TestLineSegments2()
         {
-            CheckHausdorff("LINESTRING (0 0, 2 0)", "LINESTRING (0 1, 1 2, 2 1)", "LINESTRING (1 0, 1 2)");
+            CheckHausdorff("LINESTRING (0 0, 2 0)", "LINESTRING (0 1, 1 2, 2 1)",
+                "LINESTRING (1 0, 1 2)");
         }
 
         [Test]
         public void TestLinePoints()
         {
-            CheckHausdorff("LINESTRING (0 0, 2 0)", "MULTIPOINT (0 2, 1 0, 2 1)", "LINESTRING (0 0, 0 2)");
+            CheckHausdorff("LINESTRING (0 0, 2 0)", "MULTIPOINT (0 2, 1 0, 2 1)",
+                "LINESTRING (0 0, 0 2)");
         }
 
         [Test]
         public void TestLinesTopoEqual()
         {
-            CheckDistance("MULTILINESTRING ((10 10, 10 90, 40 30), (40 30, 60 80, 90 30, 40 10))",
+            CheckDistance(
+                "MULTILINESTRING ((10 10, 10 90, 40 30), (40 30, 60 80, 90 30, 40 10))",
                 "LINESTRING (10 10, 10 90, 40 30, 60 80, 90 30, 40 10)",
                 0.0);
         }
@@ -140,13 +161,13 @@ namespace NetTopologySuite.Tests.NUnit.Algorithm.Distance
         [Test]
         public void TestLinesPolygon2()
         {
-            string a = "MULTILINESTRING ((2 3, 2 7), (9 1, 9 8, 4 9))";
-            string b = "POLYGON ((3 7, 6 8, 8 2, 3 4, 3 7))";
+            const string a = "MULTILINESTRING ((2 3, 2 7), (9 1, 9 8, 4 9))";
+            const string b = "POLYGON ((3 7, 6 8, 8 2, 3 4, 3 7))";
             CheckDistance(a, b, "LINESTRING (9 8, 6.3 7.1)");
-            // Symmetric Hausdorff: a's nearest-to-LEC-of-b vertex is a tie between (2,3) and (9,3),
-            // both at distance 3.5 from (5.5, 3). JTS's R-tree visits (2,3) first; NTS's reaches
-            // (9,3) first. The Hausdorff distance value is identical; check that instead.
-            CheckHausdorffDistanceValue(a, b, 3.5);
+            // Symmetric HD is 3.5. JTS realises (2 3, 5.5 3); NTS may pick
+            // the other vertex at the same distance. Pin the value, not the tie.
+            CheckDistanceValue(a, b, DirectedHausdorffDistance.HausdorffDistance(
+                IOUtil.ReadWKT(a), IOUtil.ReadWKT(b)), 3.5);
         }
 
         [Test]
@@ -155,6 +176,9 @@ namespace NetTopologySuite.Tests.NUnit.Algorithm.Distance
             CheckDistance("POLYGON ((2 8, 8 2, 2 1, 2 8))",
                 "LINESTRING (6 5, 4 7, 0 0, 8 4)",
                 "LINESTRING (2 8, 3.9384615384615387 6.892307692307693)");
+            CheckDistance("POLYGON ((2 8, 8 2, 2 1, 2 8))",
+                "LINESTRING (6 5, 4 7, 0 0, 8 4)",
+                2.233);
         }
 
         [Test]
@@ -168,8 +192,8 @@ namespace NetTopologySuite.Tests.NUnit.Algorithm.Distance
         [Test]
         public void TestPolygonPolygon()
         {
-            string a = "POLYGON ((2 18, 18 18, 17 3, 2 2, 2 18))";
-            string b = "POLYGON ((1 19, 5 12, 5 3, 14 10, 11 19, 19 19, 20 0, 1 1, 1 19))";
+            const string a = "POLYGON ((2 18, 18 18, 17 3, 2 2, 2 18))";
+            const string b = "POLYGON ((1 19, 5 12, 5 3, 14 10, 11 19, 19 19, 20 0, 1 1, 1 19))";
             CheckDistance(b, a, "LINESTRING (20 0, 17 3)");
             CheckDistance(a, b, "LINESTRING (6.6796875 18, 11 19)");
             CheckHausdorff(a, b, "LINESTRING (6.6796875 18, 11 19)");
@@ -178,9 +202,8 @@ namespace NetTopologySuite.Tests.NUnit.Algorithm.Distance
         [Test]
         public void TestPolygonPolygonHolesNested()
         {
-            // B is contained in A
-            string a = "POLYGON ((1 19, 19 19, 19 1, 1 1, 1 19), (6 8, 11 14, 15 7, 6 8))";
-            string b = "POLYGON ((2 18, 18 18, 18 2, 2 2, 2 18), (10 17, 3 7, 17 5, 10 17))";
+            const string a = "POLYGON ((1 19, 19 19, 19 1, 1 1, 1 19), (6 8, 11 14, 15 7, 6 8))";
+            const string b = "POLYGON ((2 18, 18 18, 18 2, 2 2, 2 18), (10 17, 3 7, 17 5, 10 17))";
             CheckDistance(a, b, "LINESTRING (9.817138671875 12.58056640625, 7.863620425230705 13.948029178901006)");
             CheckDistance(b, a, 0.0);
         }
@@ -188,15 +211,14 @@ namespace NetTopologySuite.Tests.NUnit.Algorithm.Distance
         [Test]
         public void TestMultiPolygons()
         {
-            string a = "MULTIPOLYGON (((1 1, 1 10, 5 1, 1 1)), ((4 17, 9 15, 9 6, 4 17)))";
-            string b = "MULTIPOLYGON (((1 12, 4 13, 8 10, 1 12)), ((3 8, 7 7, 6 2, 3 8)))";
+            const string a = "MULTIPOLYGON (((1 1, 1 10, 5 1, 1 1)), ((4 17, 9 15, 9 6, 4 17)))";
+            const string b = "MULTIPOLYGON (((1 12, 4 13, 8 10, 1 12)), ((3 8, 7 7, 6 2, 3 8)))";
             CheckDistance(a, b, "LINESTRING (1 1, 5.4 3.2)");
             CheckDistanceStartPtLen(b, a,
                 "LINESTRING (2.669921875 12.556640625, 5.446115154109589 13.818546660958905)",
                 0.01);
         }
 
-        // Tests that target area interiors have distance = 0
         [Test]
         public void TestLinePolygonCrossing()
         {
@@ -208,8 +230,8 @@ namespace NetTopologySuite.Tests.NUnit.Algorithm.Distance
         [Test]
         public void TestNonVertexResult()
         {
-            string wkt1 = "LINESTRING (1 1, 5 10, 9 1)";
-            string wkt2 = "LINESTRING (0 10, 0 0, 10 0)";
+            const string wkt1 = "LINESTRING (1 1, 5 10, 9 1)";
+            const string wkt2 = "LINESTRING (0 10, 0 0, 10 0)";
             CheckHausdorff(wkt1, wkt2, "LINESTRING (6.53857421875 6.5382080078125, 6.53857421875 0)");
             CheckDistance(wkt1, wkt2, "LINESTRING (6.53857421875 6.5382080078125, 6.53857421875 0)");
         }
@@ -217,8 +239,8 @@ namespace NetTopologySuite.Tests.NUnit.Algorithm.Distance
         [Test]
         public void TestDirectedLines()
         {
-            string wkt1 = "LINESTRING (1 6, 3 5, 1 4)";
-            string wkt2 = "LINESTRING (1 10, 9 5, 1 2)";
+            const string wkt1 = "LINESTRING (1 6, 3 5, 1 4)";
+            const string wkt2 = "LINESTRING (1 10, 9 5, 1 2)";
             CheckDistance(wkt1, wkt2, "LINESTRING (1 6, 2.797752808988764 8.876404494382022)");
             CheckDistance(wkt2, wkt1, "LINESTRING (9 5, 3 5)");
         }
@@ -226,31 +248,27 @@ namespace NetTopologySuite.Tests.NUnit.Algorithm.Distance
         [Test]
         public void TestDirectedLines2()
         {
-            string wkt1 = "LINESTRING (1 6, 3 5, 1 4)";
-            string wkt2 = "LINESTRING (1 3, 1 9, 9 5, 1 1)";
+            const string wkt1 = "LINESTRING (1 6, 3 5, 1 4)";
+            const string wkt2 = "LINESTRING (1 3, 1 9, 9 5, 1 1)";
             CheckDistance(wkt1, wkt2, "LINESTRING (3 5, 1 5)");
             CheckDistance(wkt2, wkt1, "LINESTRING (9 5, 3 5)");
         }
 
-        // Tests that segments are detected as interior even for a large tolerance.
         [Test]
         public void TestInteriorSegmentsLargeTol()
         {
-            string a = "POLYGON ((4 6, 5 6, 5 5, 4 5, 4 6))";
-            string b = "POLYGON ((1 9, 9 9, 9 1, 1 1, 1 9))";
-            CheckDistance(a, b, 2.0, 0.0);
+            CheckDistance("POLYGON ((4 6, 5 6, 5 5, 4 5, 4 6))",
+                "POLYGON ((1 9, 9 9, 9 1, 1 1, 1 9))",
+                2.0, 0.0);
         }
 
-        // Tests that segment endpoint nearest points which are interior to B have distance 0
         [Test]
         public void TestInteriorSegmentsSameExterior()
         {
-            string a = "POLYGON ((1 9, 3 9, 4 5, 5.05 9, 9 9, 9 1, 1 1, 1 9))";
-            string b = "POLYGON ((1 9, 9 9, 9 1, 1 1, 1 9))";
-            CheckDistance(a, b, 0.0);
+            CheckDistance("POLYGON ((1 9, 3 9, 4 5, 5.05 9, 9 9, 9 1, 1 1, 1 9))",
+                "POLYGON ((1 9, 9 9, 9 1, 1 1, 1 9))",
+                0.0);
         }
-
-        //-----------------------------------------------------
 
         [Test]
         public void TestFullyWithinDistanceEmptyPoints()
@@ -267,8 +285,8 @@ namespace NetTopologySuite.Tests.NUnit.Algorithm.Distance
         [Test]
         public void TestFullyWithinDistancePoints()
         {
-            string a = "MULTIPOINT ((1 9), (9 1))";
-            string b = "MULTIPOINT ((1 1), (9 9))";
+            const string a = "MULTIPOINT ((1 9), (9 1))";
+            const string b = "MULTIPOINT ((1 1), (9 9))";
             CheckFullyWithinDistance(a, b, 1, false);
             CheckFullyWithinDistance(a, b, 8.1, true);
         }
@@ -276,8 +294,8 @@ namespace NetTopologySuite.Tests.NUnit.Algorithm.Distance
         [Test]
         public void TestFullyWithinDistanceDisconnectedLines()
         {
-            string a = "MULTILINESTRING ((1 9, 2 9), (8 1, 9 1))";
-            string b = "LINESTRING (9 9, 1 1)";
+            const string a = "MULTILINESTRING ((1 9, 2 9), (8 1, 9 1))";
+            const string b = "LINESTRING (9 9, 1 1)";
             CheckFullyWithinDistance(a, b, 1, false);
             CheckFullyWithinDistance(a, b, 6, true);
             CheckFullyWithinDistance(b, a, 1, false);
@@ -287,8 +305,8 @@ namespace NetTopologySuite.Tests.NUnit.Algorithm.Distance
         [Test]
         public void TestFullyWithinDistanceDisconnectedPolygons()
         {
-            string a = "MULTIPOLYGON (((1 9, 2 9, 2 8, 1 8, 1 9)), ((8 2, 9 2, 9 1, 8 1, 8 2)))";
-            string b = "POLYGON ((1 2, 9 9, 2 1, 1 2))";
+            const string a = "MULTIPOLYGON (((1 9, 2 9, 2 8, 1 8, 1 9)), ((8 2, 9 2, 9 1, 8 1, 8 2)))";
+            const string b = "POLYGON ((1 2, 9 9, 2 1, 1 2))";
             CheckFullyWithinDistance(a, b, 1, false);
             CheckFullyWithinDistance(a, b, 5.3, true);
             CheckFullyWithinDistance(b, a, 1, false);
@@ -298,8 +316,8 @@ namespace NetTopologySuite.Tests.NUnit.Algorithm.Distance
         [Test]
         public void TestFullyWithinDistanceLines()
         {
-            string a = "MULTILINESTRING ((1 1, 3 3), (7 7, 9 9))";
-            string b = "MULTILINESTRING ((1 9, 1 5), (6 4, 8 2))";
+            const string a = "MULTILINESTRING ((1 1, 3 3), (7 7, 9 9))";
+            const string b = "MULTILINESTRING ((1 9, 1 5), (6 4, 8 2))";
             CheckFullyWithinDistance(a, b, 1, false);
             CheckFullyWithinDistance(a, b, 4, false);
             CheckFullyWithinDistance(a, b, 6, true);
@@ -308,8 +326,8 @@ namespace NetTopologySuite.Tests.NUnit.Algorithm.Distance
         [Test]
         public void TestFullyWithinDistancePolygons()
         {
-            string a = "POLYGON ((1 4, 4 4, 4 1, 1 1, 1 4))";
-            string b = "POLYGON ((10 10, 10 15, 15 15, 15 10, 10 10))";
+            const string a = "POLYGON ((1 4, 4 4, 4 1, 1 1, 1 4))";
+            const string b = "POLYGON ((10 10, 10 15, 15 15, 15 10, 10 10))";
             CheckFullyWithinDistance(a, b, 5, false);
             CheckFullyWithinDistance(a, b, 10, false);
             CheckFullyWithinDistance(a, b, 20, true);
@@ -318,88 +336,128 @@ namespace NetTopologySuite.Tests.NUnit.Algorithm.Distance
         [Test]
         public void TestFullyWithinDistancePolygonsNestedWithHole()
         {
-            string a = "POLYGON ((2 8, 8 8, 8 2, 2 2, 2 8))";
-            string b = "POLYGON ((1 9, 9 9, 9 1, 1 1, 1 9), (3 7, 7 7, 7 3, 3 3, 3 7))";
+            const string a = "POLYGON ((2 8, 8 8, 8 2, 2 2, 2 8))";
+            const string b = "POLYGON ((1 9, 9 9, 9 1, 1 1, 1 9), (3 7, 7 7, 7 3, 3 3, 3 7))";
             CheckFullyWithinDistance(a, b, 1, false);
             CheckFullyWithinDistance(a, b, 2, true);
             CheckFullyWithinDistance(a, b, 3, true);
         }
 
-        //======================================================================
-
-        private void CheckHausdorff(string wkt1, string wkt2, string wktExpected)
+        /// <summary>
+        /// Discrete under-estimate witness from DiscreteHausdorffDistance remarks.
+        /// On the spike (100 0)–(10 100), min-distance to B's two arms is equal at
+        /// t = 11/19: point (910/19, 1100/19), distance 910/19.
+        /// </summary>
+        [Test]
+        public void TestDiscreteUnderEstimateWitness()
         {
-            var g1 = Read(wkt1);
-            var g2 = Read(wkt2);
+            const string a = "LINESTRING (0 0, 100 0, 10 100, 10 100)";
+            const string b = "LINESTRING (0 100, 0 10, 80 10)";
+            var g1 = IOUtil.ReadWKT(a);
+            var g2 = IOUtil.ReadWKT(b);
+
+            double discrete = DiscreteHausdorffDistance.Distance(g1, g2);
+            double locus = DirectedHausdorffDistance.HausdorffDistance(g1, g2);
+
+            Assert.That(discrete, Is.LessThanOrEqualTo(22.360679774997898 + 1e-9));
+            const double locusHd = 910.0 / 19.0;
+            Assert.That(locus, Is.EqualTo(locusHd).Within(0.05));
+        }
+
+        /// <summary>
+        /// Identical long linestring is zero via JTS isSameOrCollinear skip.
+        /// Distance is the assertion; no wall-clock bound.
+        /// </summary>
+        [Test]
+        public void TestIdenticalLongLinestring()
+        {
+            const int n = 2000;
+            var cs = new Coordinate[n];
+            for (int i = 0; i < n; i++)
+                cs[i] = new Coordinate(i, 0.0);
+            var line = GeometryFactory.Floating.CreateLineString(cs);
+            double dist = DirectedHausdorffDistance.Distance(line, line);
+            Assert.That(dist, Is.EqualTo(0.0).Within(Tolerance));
+        }
+
+        private static void CheckHausdorff(string wkt1, string wkt2, string wktExpected)
+        {
+            var g1 = IOUtil.ReadWKT(wkt1);
+            var g2 = IOUtil.ReadWKT(wkt2);
             var pts = DirectedHausdorffDistance.HausdorffDistancePoints(g1, g2);
             var result = g1.Factory.CreateLineString(pts);
-            var expected = Read(wktExpected);
-            CheckEqualResult(expected, result);
+            var expected = IOUtil.ReadWKT(wktExpected);
+            Assert.That(result.EqualsExact(expected, Tolerance), Is.True,
+                $"expected {expected} but was {result}");
         }
 
-        private void CheckDistance(string wkt1, string wkt2, string wktExpected)
+        private static void CheckDistance(string wkt1, string wkt2, string wktExpected)
         {
-            var g1 = Read(wkt1);
-            var g2 = Read(wkt2);
+            var g1 = IOUtil.ReadWKT(wkt1);
+            var g2 = IOUtil.ReadWKT(wkt2);
             var pts = DirectedHausdorffDistance.DistancePoints(g1, g2);
             var result = g1.Factory.CreateLineString(pts);
-            var expected = Read(wktExpected);
-            CheckEqualResult(expected, result);
+            var expected = IOUtil.ReadWKT(wktExpected);
+            Assert.That(result.EqualsExact(expected, Tolerance), Is.True,
+                $"expected {expected} but was {result}");
         }
 
-        private void CheckDistance(string wkt1, string wkt2, double tolerance, string wktExpected)
+        private static void CheckDistance(string wkt1, string wkt2, double tolerance, string wktExpected)
         {
-            var g1 = Read(wkt1);
-            var g2 = Read(wkt2);
+            var g1 = IOUtil.ReadWKT(wkt1);
+            var g2 = IOUtil.ReadWKT(wkt2);
             var pts = DirectedHausdorffDistance.DistancePoints(g1, g2, tolerance);
             var result = g1.Factory.CreateLineString(pts);
-            var expected = Read(wktExpected);
-            CheckEqualResult(expected, result);
+            var expected = IOUtil.ReadWKT(wktExpected);
+            Assert.That(result.EqualsExact(expected, Tolerance), Is.True,
+                $"expected {expected} but was {result}");
         }
 
-        private void CheckDistanceStartPtLen(string wkt1, string wkt2,
+        private static void CheckDistanceStartPtLen(string wkt1, string wkt2,
             string wktExpected, double resultTolerance)
         {
-            var g1 = Read(wkt1);
-            var g2 = Read(wkt2);
+            var g1 = IOUtil.ReadWKT(wkt1);
+            var g2 = IOUtil.ReadWKT(wkt2);
             var pts = DirectedHausdorffDistance.DistancePoints(g1, g2);
             var result = g1.Factory.CreateLineString(pts);
-            var expected = Read(wktExpected);
+            var expected = IOUtil.ReadWKT(wktExpected);
 
-            var resultPt = result.Coordinates[0];
-            var expectedPt = expected.Coordinates[0];
-            CheckEqualXY(expectedPt, resultPt, resultTolerance);
-
-            double distResult = result.Length;
-            double distExpected = expected.Length;
-            Assert.That(distResult, Is.EqualTo(distExpected).Within(resultTolerance));
+            Assert.That(result.Coordinate.Equals2D(expected.Coordinate, resultTolerance), Is.True,
+                $"start expected {expected.Coordinate} but was {result.Coordinate}");
+            Assert.That(result.Length, Is.EqualTo(expected.Length).Within(resultTolerance));
         }
 
-        private void CheckDistance(string wkt1, string wkt2, double tolerance, double expectedDistance)
+        private static void CheckDistance(string wkt1, string wkt2, double tolerance, double expectedDistance)
         {
-            var g1 = Read(wkt1);
-            var g2 = Read(wkt2);
+            var g1 = IOUtil.ReadWKT(wkt1);
+            var g2 = IOUtil.ReadWKT(wkt2);
             double distResult = DirectedHausdorffDistance.Distance(g1, g2, tolerance);
             Assert.That(distResult, Is.EqualTo(expectedDistance).Within(Tolerance));
         }
 
-        private void CheckDistance(string wkt1, string wkt2, double expectedDistance)
+        private static void CheckDistance(string wkt1, string wkt2, double expectedDistance)
         {
-            var g1 = Read(wkt1);
-            var g2 = Read(wkt2);
+            var g1 = IOUtil.ReadWKT(wkt1);
+            var g2 = IOUtil.ReadWKT(wkt2);
             double distResult = DirectedHausdorffDistance.Distance(g1, g2);
             Assert.That(distResult, Is.EqualTo(expectedDistance).Within(Tolerance));
         }
 
-        private void CheckFullyWithinDistance(string a, string b, double distance, bool expected)
+        private static void CheckDistanceValue(string wkt1, string wkt2, double actual, double expected)
         {
-            var g1 = Read(a);
-            var g2 = Read(b);
+            Assert.That(actual, Is.EqualTo(expected).Within(Tolerance),
+                $"HausdorffDistance({wkt1}, {wkt2})");
+        }
+
+        private static void CheckFullyWithinDistance(string a, string b, double distance, bool expected)
+        {
+            var g1 = IOUtil.ReadWKT(a);
+            var g2 = IOUtil.ReadWKT(b);
             bool result = DirectedHausdorffDistance.IsFullyWithinDistance(g1, g2, distance);
             Assert.That(result, Is.EqualTo(expected));
         }
 
-        private void CheckFullyWithinDistanceEmpty(string a, string b)
+        private static void CheckFullyWithinDistanceEmpty(string a, string b)
         {
             CheckFullyWithinDistance(a, b, 0, false);
             CheckFullyWithinDistance(b, a, 0, false);
@@ -409,37 +467,14 @@ namespace NetTopologySuite.Tests.NUnit.Algorithm.Distance
             CheckFullyWithinDistance(b, a, 1000, false);
         }
 
-        private void CheckDistanceEmpty(string a, string b)
+        private static void CheckDistanceEmpty(string a, string b)
         {
-            var g1 = Read(a);
-            var g2 = Read(b);
+            var g1 = IOUtil.ReadWKT(a);
+            var g2 = IOUtil.ReadWKT(b);
 
-            var resultPts = DirectedHausdorffDistance.DistancePoints(g1, g2);
-            Assert.That(resultPts, Is.Null);
-
-            double resultDist = DirectedHausdorffDistance.Distance(g1, g2);
-            Assert.That(double.IsNaN(resultDist), Is.True);
-
-            double hausdorffDist = DirectedHausdorffDistance.HausdorffDistance(g1, g2);
-            Assert.That(double.IsNaN(hausdorffDist), Is.True);
-        }
-
-        private void CheckHausdorffDistanceValue(string wkt1, string wkt2, double expectedDistance)
-        {
-            var g1 = Read(wkt1);
-            var g2 = Read(wkt2);
-            double distResult = DirectedHausdorffDistance.HausdorffDistance(g1, g2);
-            Assert.That(distResult, Is.EqualTo(expectedDistance).Within(Tolerance));
-        }
-
-        private void CheckEqualResult(Geometry expected, Geometry actual)
-        {
-            bool equal = actual.EqualsExact(expected, Tolerance);
-            if (!equal)
-            {
-                TestContext.WriteLine($"FAIL:\nExpected = {expected}\nActual   = {actual}");
-            }
-            Assert.That(equal, Is.True);
+            Assert.That(DirectedHausdorffDistance.DistancePoints(g1, g2), Is.Null);
+            Assert.That(DirectedHausdorffDistance.Distance(g1, g2), Is.NaN);
+            Assert.That(DirectedHausdorffDistance.HausdorffDistance(g1, g2), Is.NaN);
         }
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Merge of the locus DirectedHausdorff engine from `cursor/nts-dhd-ccfa` onto `port/directed-hausdorff` (NTS #812 / JTS #1182).

This is the same work as fork PR 22, landed on the existing `#846` head so upstream https://github.com/NetTopologySuite/NetTopologySuite/pull/846 picks it up.

**Against this fork’s `develop` the file list is noisy** (this branch tracks upstream `develop` + DHD, not the fork’s SQL/MM line). Review the DHD files, or review #846.

What this merge adds on top of the May thin wrappers:

- `CoordinateSequenceLocation` + `FacetSequence.NearestLocation`
- Real STRtree `IndexedFacetDistance` nearest-location / segment distance
- TestRunner `DirectedHausdorffDistance` / `DirectedHausdorffLine` / `HausdorffLine`
- Witness pair: discrete ≤ 22.36, locus HD 910/19 ± 0.05
- Identical 2000-vertex `distance == 0` canary (no wall-clock)

`DiscreteHausdorffDistance` unchanged. Do not remint `423-a` / `D-HF`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc93a9b6-cabf-416a-943d-5dcc8901ccfa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc93a9b6-cabf-416a-943d-5dcc8901ccfa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

